### PR TITLE
fix: preserve custom domain configuration during GitHub Pages deployment

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+bene-ergo.stability.nexus


### PR DESCRIPTION
This pull request fixes #23 by adding a CNAME file with the custom domain name to the static folder. This ensures the custom domain configuration is preserved during GitHub Pages deployment.