### PR TITLE
Fix: Replace Height-Based Validation With Timestamp-Based Validation 

### DIFF
--- a/contracts/forum_contract/reputation_proof.es
+++ b/contracts/forum_contract/reputation_proof.es
@@ -131,7 +131,7 @@
         // Extract the token IDs from the collection of type NFT boxes
         val availableTypeTokenIds: Coll[Coll[Byte]] = CONTEXT.dataInputs.filter { (b: Box) =>
           blake2b256(b.propositionBytes) == DIGITAL_PUBLIC_GOOD &&
-          b.creationInfo._1 < CONTEXT.HEIGHT
+          b.creationInfo._2 <= CONTEXT.preHeader.timestamp
         }.map { (b: Box) => 
           b.tokens(0)._1
         }


### PR DESCRIPTION
## Replace Height-Based Validation With Timestamp-Based Validation 

Fixes issue #55 

Replaced the old height-based validation:
`b.creationInfo._1 < CONTEXT.HEIGHT`

with a timestamp-based check:
`b.creationInfo._2 <= CONTEXT.preHeader.timestamp`

This aligns with the v2 requirement to use time-based validation and ensures more accurate behavior since block intervals are not always consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the reputation validation mechanism to use timestamp-based checks for data input verification, improving the accuracy of the validation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->