### PR TITLE
feat: fixed theme toggle visiblity on smaller devices

### DIFF
--- a/src/routes/App.svelte
+++ b/src/routes/App.svelte
@@ -471,19 +471,9 @@
         }
     }
 
-    /* Dropdown menu z-index - ensures dropdowns appear above all content including mobile menu */
-    :global(.bits-dropdown-menu-content-wrapper),
-    :global(.bits-dropdown-menu-content),
-    :global([data-bits-menu-content]),
-    :global([role="menu"]) {
-        position: fixed !important;
+    /* Theme dropdown z-index - ensures theme menu appears above mobile menu */
+    :global(.theme-dropdown-content) {
         z-index: 9999 !important;
-        pointer-events: auto !important;
-    }
-
-    :global(.bits-dropdown-menu-root-open) {
-        position: static !important;
-        overflow: visible !important;
     }
 
     /* Navbar Styles */

--- a/src/routes/Theme.svelte
+++ b/src/routes/Theme.svelte
@@ -19,7 +19,7 @@
     <span class="sr-only">Toggle theme</span>
     </Button>
 </DropdownMenu.Trigger>
-<DropdownMenu.Content align="end">
+<DropdownMenu.Content align="end" class="theme-dropdown-content">
     <DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
     <DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
     <DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>


### PR DESCRIPTION
Regarding #82 

<img width="597" height="621" alt="Screenshot 2025-12-13 at 1 10 38 PM" src="https://github.com/user-attachments/assets/a5808c0a-0ba8-4c97-a573-e55c0b9a56e1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile navigation footer with a theme toggle positioned below mobile links to centralize theme control.

* **Style / Responsive**
  * Adjusted stacking order so header, mobile panel, and theme dropdown render above other UI.
  * Added mobile-specific styles for a full-width, bordered theme toggle and responsive centering to preserve layout on small screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->