### PR TITLE
Fix: Add Settings Menu to Mobile Navigation

### DIFF
--- a/src/routes/App.svelte
+++ b/src/routes/App.svelte
@@ -338,6 +338,29 @@
                     New Campaign
                 </a>
             </li>
+            <li>
+                <a href="#" on:click={() => {
+                    showSettingsModal = true;
+                    mobileMenuOpen = false;
+                }}>
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="flex-shrink: 0;"
+                    >
+                        <circle cx="12" cy="12" r="3"></circle>
+                        <path d="M12 1v6m0 6v6m5.2-13.2l-4.2 4.2m0 6l4.2 4.2M23 12h-6m-6 0H1m18.2 5.2l-4.2-4.2m0-6l4.2-4.2"></path>
+                    </svg>
+                    Settings
+                </a>
+            </li>
         </ul>
     </div>
 {/if}
@@ -709,7 +732,9 @@
         text-decoration: none;
         font-weight: 500;
         padding: 0.75rem;
-        display: block;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
         border-radius: 8px;
         transition: all 0.2s ease;
     }


### PR DESCRIPTION
# Fix: Add Settings Menu to Mobile Navigation

## Problem

Settings icon is only visible on large screens (≥1024px) but completely hidden on mobile and tablet devices, making settings **completely inaccessible** for users on smaller screens.

**Current Behavior:**
- Desktop: Settings icon visible in header ✅
- Mobile/Tablet: Settings icon hidden, no alternative access ❌

**Root Cause:**
CSS rule at line 759-761 in `App.svelte`:
```css
/* Force settings and theme off on mobile to save space */
.theme-toggle, .settings-button {
    display: none !important;
}
```

## Solution

Added settings menu item to the mobile hamburger navigation menu while preserving existing desktop behavior.

### Changes Made

**File:** `src/routes/App.svelte`

#### 1. Added Settings to Mobile Menu (Lines 341-364)
- New menu item with settings icon (gear SVG)
- Click handler opens settings modal
- **Auto-closes mobile menu** after selection
- Matches styling of other mobile nav items

#### 2. Updated Mobile Nav Styles (Lines 730-740)
- Changed `display: block` to `display: flex`
- Added `align-items: center` and `gap: 0.5rem`
- Enables icon + text layout

### Key Features
- ✅ Settings accessible on all device sizes
- ✅ Desktop behavior unchanged (settings in header)
- ✅ Mobile menu closes automatically after clicking settings
- ✅ Follows existing code patterns
- ✅ Minimal, surgical changes (1 file, +26/-1 lines)

## Testing

### Test Video

<video
  src="https://github.com/user-attachments/assets/5e57ee64-167a-4254-8382-de34bd65f0b8"
  autoplay
  muted
  loop
  playsinline
  controls
  width="100%">
</video>


### Desktop View (≥1024px)
- [x] Settings icon visible in header
- [x] Clicking opens settings modal
- [x] No hamburger menu visible

### Mobile View (<1024px)
- [x] Settings icon hidden in header
- [x] Hamburger menu button visible
- [x] Settings option appears in mobile menu with icon
- [x] Clicking settings opens modal
- [x] Mobile menu closes automatically

## How to Test

```bash
# Checkout the branch
git checkout fix/settings-menu-mobile-access

# Install dependencies (if needed)
npm install

# Run dev server
npm run dev

# Visit http://localhost:5173
```

**Desktop Test:**
1. Open in browser (wide screen)
2. Verify settings icon in header (top right)
3. Click settings icon → modal opens

**Mobile Test:**
1. Resize browser to mobile width (~375px) or use DevTools mobile emulation
2. Verify settings icon NOT in header
3. Click hamburger menu button
4. Verify "Settings" option with gear icon appears
5. Click "Settings" → modal opens, menu closes

## Files Changed

```
src/routes/App.svelte
  - Added settings menu item to mobile navigation (lines 341-364)
  - Updated mobile nav link styles for icon support (lines 730-740)
  - Total: +26 lines, -1 line
```

## Checklist

- [x] Code follows existing style and patterns
- [x] No unrelated files modified
- [x] Tested on desktop viewport
- [x] Tested on mobile viewport
- [x] Settings modal opens correctly
- [x] Mobile menu closes after selection
- [x] No breaking changes
- [x] Conventional commit message used

## Related Issues

Fixes #85

---

**Ready for review!** 🚀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Settings option to mobile navigation for quick access to app settings.

* **Improvements**
  * Enhanced navigation layout on desktop and mobile with improved spacing and visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->