### PR TITLE
Streamline theme toggle to one-click buttons #120

### DIFF
--- a/src/routes/Theme.svelte
+++ b/src/routes/Theme.svelte
@@ -1,27 +1,110 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import Sun from "lucide-svelte/icons/sun";
     import Moon from "lucide-svelte/icons/moon";
+    import Monitor from "lucide-svelte/icons/monitor";
 
     import { resetMode, setMode } from "mode-watcher";
-    import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
-    import { Button } from "$lib/components/ui/button/index.js";
+
+    type ThemeOption = "light" | "dark" | "system";
+
+    const options: { value: ThemeOption; label: string; icon: typeof Sun }[] = [
+        { value: "light", label: "Light", icon: Sun },
+        { value: "dark", label: "Dark", icon: Moon },
+        { value: "system", label: "System", icon: Monitor },
+    ];
+
+    let preference: ThemeOption = "system";
+
+    onMount(() => {
+        if (typeof localStorage === "undefined") return;
+
+        const stored = localStorage.getItem("mode-watcher");
+        preference = stored === "light" || stored === "dark" ? stored : "system";
+    });
+
+    function selectTheme(next: ThemeOption) {
+        preference = next;
+
+        if (next === "system") {
+            resetMode();
+            return;
+        }
+
+        setMode(next);
+    }
 </script>
 
-<DropdownMenu.Root>
-<DropdownMenu.Trigger asChild let:builder>
-    <Button builders={[builder]} variant="outline" size="icon">
-    <Sun
-    class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
-    />
-    <Moon
-    class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
-    />
-    <span class="sr-only">Toggle theme</span>
-    </Button>
-</DropdownMenu.Trigger>
-<DropdownMenu.Content align="end">
-    <DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
-    <DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
-    <DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>
-</DropdownMenu.Content>
-</DropdownMenu.Root>
+<div class="theme-toggle" role="group" aria-label="Theme selector">
+    {#each options as option}
+        <button
+            class={`theme-button ${preference === option.value ? "active" : ""}`}
+            type="button"
+            on:click={() => selectTheme(option.value)}
+            aria-pressed={preference === option.value}
+            title={`${option.label} theme`}
+        >
+            <svelte:component this={option.icon} class="icon" />
+            <span class="label">{option.label}</span>
+        </button>
+    {/each}
+</div>
+
+<style>
+    .theme-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem;
+        border-radius: 9999px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        backdrop-filter: blur(6px);
+        -webkit-backdrop-filter: blur(6px);
+    }
+
+    .theme-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.65rem;
+        border-radius: 9999px;
+        border: 1px solid transparent;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font-size: 0.85rem;
+        transition: all 0.18s ease;
+    }
+
+    .theme-button .icon {
+        width: 1rem;
+        height: 1rem;
+    }
+
+    .theme-button:hover {
+        background: rgba(255, 165, 0, 0.12);
+        color: orange;
+    }
+
+    .theme-button.active {
+        background: rgba(255, 165, 0, 0.18);
+        border-color: rgba(255, 165, 0, 0.35);
+        color: orange;
+        box-shadow: 0 0 0.5rem rgba(255, 165, 0, 0.25);
+    }
+
+    .label {
+        line-height: 1;
+    }
+
+    @media (max-width: 1024px) {
+        .label {
+            display: none;
+        }
+
+        .theme-button {
+            padding: 0.35rem;
+        }
+    }
+</style>


### PR DESCRIPTION
- Replaced the navbar theme dropdown with an inline three-button control (Light/Dark/System).
- Kept the existing mode-watcher behavior and persistence (light/dark/system; system default); only the interaction model changed to single-click.
- Added pill-style styling with active state; labels hide on smaller screens to stay compact.

<img width="1886" height="925" alt="image" src="https://github.com/user-attachments/assets/faa2b0e1-e8e9-4f25-8d47-1a4d66dee2c9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned theme selector with an accessible button group interface replacing the previous dropdown menu, featuring inline options with icons.

* **Style**
  * Enhanced styling with responsive label hiding, improved hover effects, and clearer active state indicators for better visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->