### PR TITLE
Fix/theme toggle button

### DIFF
--- a/src/routes/Theme.svelte
+++ b/src/routes/Theme.svelte
@@ -6,12 +6,6 @@
   import { Button } from "$lib/components/ui/button/index.js";
 
   function toggleTheme() {
-    // If system mode is active, default to dark on first click
-    if ($mode === "system") {
-      setMode("dark");
-      return;
-    }
-
     setMode($mode === "dark" ? "light" : "dark");
   }
 </script>


### PR DESCRIPTION
## Summary

This PR replaces the theme dropdown menu in the navigation bar with a one-click toggle button to improve usability and reduce interaction friction.

## Problem

The previous theme switcher required multiple steps:
1. Open dropdown
2. Select theme
3. Confirm selection

This was inefficient for a frequently used feature.

## Solution

- Removed the dropdown menu
- Added a single-click Light ↔ Dark toggle button
- Preserved existing Sun/Moon animations
- Kept `mode-watcher` for theme persistence
- Ensured accessibility with screen-reader labels

## Behavior

- Light → Dark on click
- Dark → Light on click
- System → Dark on first interaction (safe default)

## Screenshots

| Before | After |
|------|------|
| Dropdown-based selector | One-click toggle |

## Checklist

- [x] One-click theme toggle
- [x] No dropdown interaction
- [x] Keyboard accessible
- [x] Theme persists on refresh
- [x] No visual regression

Closes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the theme toggle interface from a dropdown menu with multiple options to a single icon button that toggles between themes on click.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->