### PR TITLE
Optimize direct campaign URL loading to skip full list fetch

### DIFF
--- a/src/lib/common/load_by_id.ts
+++ b/src/lib/common/load_by_id.ts
@@ -1,17 +1,33 @@
 import { type Project } from "./project";
 import { project_detail } from "./store";
-import { fetchProjects } from "$lib/ergo/fetch";
+import { fetchProjects, fetchSingleProject } from "$lib/ergo/fetch";
 
-export async function loadProjectById(projectId: string) {
+/**
+ * Load a project by its ID, with optional direct fetch mode
+ * @param projectId - The project/campaign token ID
+ * @param directFetch - If true, fetches only this project instead of loading all campaigns
+ */
+export async function loadProjectById(projectId: string, directFetch: boolean = false) {
     try {
-        const projects: Map<string, Project> = await fetchProjects(true);
-        const project = projects.get(projectId);
+        let project: Project | null = null;
+        
+        if (directFetch) {
+            // Direct mode: fetch only the specific campaign
+            console.log(`[loadProjectById] Direct fetch mode for project: ${projectId}`);
+            project = await fetchSingleProject(projectId);
+        } else {
+            // Legacy mode: load all projects first
+            console.log(`[loadProjectById] Loading from full project list: ${projectId}`);
+            const projects: Map<string, Project> = await fetchProjects(true);
+            project = projects.get(projectId) || null;
+        }
         
         if (!project) {
             throw new Error(`Project with ID ${projectId} not found.`);
         }
         
         project_detail.set(project);
+        console.log(`[loadProjectById] Successfully loaded project: ${projectId}`);
     } catch (error) {
         console.error(`Failed to load project: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -308,6 +308,180 @@ export async function fetchProjectsFromBlockchain() {
     }
 }
 
+/**
+ * Fetch a single project by its token ID directly from blockchain
+ * This bypasses the full project list fetch for direct campaign access
+ */
+export async function fetchSingleProject(projectId: string): Promise<Project | null> {
+    console.log(`Fetching single project: ${projectId}`);
+    
+    const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
+    
+    try {
+        for (const version of versions) {
+            const template = get_template_hash(version);
+            const url = get(explorer_uri) + '/api/v1/boxes/unspent/search';
+            
+            // Search for boxes with the specific token ID
+            const response = await fetch(url + '?' + new URLSearchParams({
+                offset: '0',
+                limit: '10',
+            }), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    "ergoTreeTemplateHash": template,
+                    "registers": {},
+                    "constants": {},
+                    "assets": [{
+                        "tokenId": projectId
+                    }]
+                }),
+            });
+
+            if (!response.ok) {
+                console.error('Error while fetching single project');
+                continue;
+            }
+
+            const json_data = await response.json();
+
+            if (!json_data.items || json_data.items.length === 0) {
+                continue;
+            }
+
+            // Process the first matching box
+            const e = json_data.items[0];
+            
+            if (!hasValidSigmaTypes(e.additionalRegisters, version)) {
+                console.warn(`Box ${e.boxId} has invalid sigma types`);
+                continue;
+            }
+
+            let constants: ConstantContent | null = null;
+
+            if (version === "v1_0" || version === "v1_1") {
+                constants = getConstantContent(hexToUtf8(e.additionalRegisters.R8.renderedValue) ?? "");
+                if (constants === null) {
+                    console.warn("constants null");
+                    continue;
+                }
+            } else {
+                try {
+                    if (!e.additionalRegisters.R8) throw new Error("R8 missing");
+
+                    const rawValues = e.additionalRegisters.R8.renderedValue
+                        .replace(/[\[\]"'\s]/g, "")
+                        .split(",")
+                        .filter((s: string) => s.length > 0);
+
+                    if (rawValues.length < 3) throw new Error("Insufficient R8 constants");
+
+                    constants = {
+                        owner: rawValues[0],
+                        dev_hash: rawValues[1],
+                        dev_fee: parseInt(rawValues[2], 16),
+                        pft_token_id: rawValues[3],
+                        base_token_id: rawValues[4] ?? "",
+                        raw: e.additionalRegisters.R8.serializedValue
+                    };
+                } catch (err) {
+                    console.warn("Failed to parse R8 constants", err);
+                    continue;
+                }
+            }
+
+            let project_id = e.assets[0].tokenId;
+            let token_id = constants.pft_token_id;
+            let [token_amount_sold, refunded_token_amount, auxiliar_exchange_counter] = JSON.parse(e.additionalRegisters.R6.renderedValue);
+
+            let exchange_rate = parseInt(e.additionalRegisters.R7.renderedValue);
+            let base_token_id = constants.base_token_id ?? "";
+
+            let current_pft_amount = (e.assets.find((asset: any) => asset.tokenId === constants.pft_token_id)?.amount) ?? 0;
+            let total_pft_amount = current_pft_amount + auxiliar_exchange_counter;
+            let unsold_pft_amount = current_pft_amount - token_amount_sold + refunded_token_amount + auxiliar_exchange_counter;
+            let current_erg_value = e.value - Number(SAFE_MIN_BOX_VALUE);
+            let minimum_token_amount = parseInt(e.additionalRegisters.R5.renderedValue);
+
+            let block_limit: number = 0;
+            let is_timestamp_limit = false;
+            if (version === "v2") {
+                const r4Value = JSON.parse(e.additionalRegisters.R4?.renderedValue.replace(/\[([a-f0-9]+)(,.*)/, '["$1"$2'));
+                if (!Array.isArray(r4Value) || r4Value.length < 2) throw new Error("R4 is not a valid tuple (Type, Deadline).");
+
+                is_timestamp_limit = r4Value[0] === true;
+                block_limit = Number(r4Value[1]);
+            } else {
+                block_limit = parseInt(e.additionalRegisters.R4.renderedValue);
+            }
+
+            let base_token_details = undefined;
+            if (base_token_id && base_token_id !== "" && base_token_id !== undefined && base_token_id !== "00".repeat(32)) {
+                try {
+                    base_token_details = await fetch_token_details(base_token_id);
+                } catch (error) {
+                    console.warn(`Failed to fetch base token details for ${base_token_id}:`, error);
+                }
+            }
+
+            const project: Project = {
+                version: version,
+                platform: new ErgoPlatform(),
+                box: {
+                    boxId: e.boxId,
+                    value: e.value,
+                    assets: e.assets,
+                    ergoTree: e.ergoTree,
+                    creationHeight: e.creationHeight,
+                    additionalRegisters: Object.entries(e.additionalRegisters).reduce((acc, [key, value]) => {
+                        acc[key] = (value as any).serializedValue;
+                        return acc;
+                    }, {} as { [key: string]: string; }),
+                    index: e.index,
+                    transactionId: e.transactionId
+                },
+                project_id: project_id,
+                current_idt_amount: e.assets[0].amount,
+                pft_token_id: constants.pft_token_id,
+                base_token_id: base_token_id,
+                base_token_details: base_token_details,
+                block_limit: block_limit,
+                is_timestamp_limit: is_timestamp_limit,
+                minimum_amount: minimum_token_amount,
+                maximum_amount: total_pft_amount,
+                total_pft_amount: total_pft_amount,
+                current_pft_amount: current_pft_amount,
+                unsold_pft_amount: unsold_pft_amount,
+                refund_counter: refunded_token_amount,
+                sold_counter: token_amount_sold,
+                auxiliar_exchange_counter: auxiliar_exchange_counter,
+                exchange_rate: exchange_rate,
+                content: getProjectContent(
+                    token_id.slice(0, 8),
+                    hexToUtf8(e.additionalRegisters.R9.renderedValue) ?? ""
+                ),
+                constants: constants,
+                value: e.value,
+                current_value: current_erg_value,
+                token_details: await fetch_token_details(token_id)
+            };
+
+            // Cache the project in the store
+            const current = get(projects).data;
+            current.set(project_id, project);
+            projects.set({ data: current, last_fetch: get(projects).last_fetch });
+
+            console.log(`Successfully fetched project: ${projectId}`);
+            return project;
+        }
+    } catch (error) {
+        console.error(`Error fetching single project ${projectId}:`, error);
+    }
+
+    return null;
+}
+
 export async function fetchProjects(force: boolean = false): Promise<Map<string, Project>> {
 
     const current = get(projects);

--- a/src/routes/App.svelte
+++ b/src/routes/App.svelte
@@ -67,8 +67,11 @@
         const projectId = $page.url.searchParams.get("project") || $page.url.searchParams.get("campaign");
         const platformId = $page.url.searchParams.get("chain");
 
+        // Direct campaign access: skip full list load and fetch only the target campaign
         if (projectId && platformId == platform.id) {
-            await loadProjectById(projectId, platform);
+            console.log(`[App] Direct campaign access detected: ${projectId}`);
+            await loadProjectById(projectId, true); // true = direct fetch mode
+            activeTab = "projectDetails"; // Switch to project details view
         }
 
         // Setup footer scrolling text


### PR DESCRIPTION
- Add fetchSingleProject() function to fetch individual campaigns by token ID
- Update loadProjectById() with directFetch parameter to bypass full list loading
- Modify App.svelte onMount to detect and handle direct campaign access via URL
- When chain and campaign params are present, fetch only the target campaign
- Automatically switch to projectDetails tab for direct campaign access

This optimization significantly improves loading performance for direct campaign URLs by avoiding unnecessary blockchain API calls to fetch the entire campaign list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now navigate directly to specific project details by ID, bypassing the full project list load.

* **Improvements**
  * Enhanced project data validation and parsing for improved reliability.
  * Optimized loading performance with more efficient project access capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->