### PR TITLE
Add ?search= URL parameter sync for all three list views

### DIFF
--- a/src/routes/App.svelte
+++ b/src/routes/App.svelte
@@ -42,6 +42,7 @@
     let showWalletInfo = false;
     let mobileMenuOpen = false;
     let showSettingsModal = false;
+    let searchQuery = "";
 
     // Reference to the wallet button wrapper to detect outside clicks
     let walletButtonWrapper: HTMLElement | null = null;
@@ -66,6 +67,11 @@
 
         const projectId = $page.url.searchParams.get("project") || $page.url.searchParams.get("campaign");
         const platformId = $page.url.searchParams.get("chain");
+        const searchParam = $page.url.searchParams.get("search");
+
+        if (searchParam) {
+            searchQuery = searchParam;
+        }
 
         if (projectId && platformId == platform.id) {
             await loadProjectById(projectId, platform);
@@ -161,7 +167,22 @@
         window.history.pushState({}, "", url);
     }
 
+    function updateSearchUrl(search: string) {
+        if (typeof window === "undefined") return;
+
+        const url = new URL(window.location.href);
+
+        if (search && search.trim() !== "") {
+            url.searchParams.set("search", search);
+        } else {
+            url.searchParams.delete("search");
+        }
+
+        window.history.pushState({}, "", url);
+    }
+
     $: changeUrl($project_detail);
+    $: updateSearchUrl(searchQuery);
 
     // Function to update wallet information periodically
     async function updateWalletInfo() {
@@ -345,13 +366,13 @@
 <main class="responsive-main">
     {#if $project_detail === null}
         {#if activeTab === "acquireTokens"}
-            <TokenAcquisition />
+            <TokenAcquisition bind:searchQuery />
         {/if}
         {#if activeTab === "myContributions"}
-            <MyContributions />
+            <MyContributions bind:searchQuery />
         {/if}
         {#if activeTab === "myProjects"}
-            <MyProjects />
+            <MyProjects bind:searchQuery />
         {/if}
         {#if activeTab === "submitProject"}
             <NewProject />

--- a/src/routes/MyContributions.svelte
+++ b/src/routes/MyContributions.svelte
@@ -6,6 +6,8 @@
     import { user_tokens, address } from "$lib/common/store";
     import { walletConnected } from "wallet-svelte-component";
 
+    export let searchQuery: string = "";
+
     let platform = new ErgoPlatform();
 
     const filter = async (project: Project) => {
@@ -43,4 +45,4 @@
     });
 </script>
 
-<ProjectList filterProject={filter}>My Contributions</ProjectList>
+<ProjectList filterProject={filter} bind:searchQuery>My Contributions</ProjectList>

--- a/src/routes/MyProjects.svelte
+++ b/src/routes/MyProjects.svelte
@@ -4,6 +4,8 @@
     import { ErgoAddress } from "@fleet-sdk/core";
     import ProjectList from "./ProjectList.svelte";
 
+    export let searchQuery: string = "";
+
     const filter = async (project: Project) => {
         // Only show projects if wallet is connected and matches owner
         if (!$address) return false;
@@ -13,4 +15,4 @@
     };
 </script>
 
-<ProjectList filterProject={filter}>My Campaigns</ProjectList>
+<ProjectList filterProject={filter} bind:searchQuery>My Campaigns</ProjectList>

--- a/src/routes/ProjectList.svelte
+++ b/src/routes/ProjectList.svelte
@@ -19,7 +19,7 @@
     let isFiltering: boolean = false;
     let totalProjectsCount: number = 0;
 
-    let searchQuery: string = "";
+    export let searchQuery: string = "";
     let sortBy: "newest" | "oldest" | "amount" | "name" = "newest";
     let hideTestProjects: boolean = true;
     let filterOpen = false;

--- a/src/routes/TokenAcquisition.svelte
+++ b/src/routes/TokenAcquisition.svelte
@@ -2,9 +2,11 @@
     import ProjectList from "./ProjectList.svelte";
     import { type Project } from "$lib/common/project";
 
+    export let searchQuery: string = "";
+
     async function projectFilter(project: Project) {
         return true;
     }
 </script>
 
-<ProjectList filterProject={projectFilter}>Fundraising Campaigns</ProjectList>
+<ProjectList filterProject={projectFilter} bind:searchQuery>Fundraising Campaigns</ProjectList>


### PR DESCRIPTION
- Make searchQuery exportable in ProjectList.svelte
- Add searchQuery state management in App.svelte
- Pass searchQuery to all three list components (TokenAcquisition, MyProjects, MyContributions)
- Read ?search= parameter from URL on mount and initialize searchQuery
- Add updateSearchUrl() function to sync search filter changes with URL
- Implement bidirectional sync: URL changes update filter, filter changes update URL
- Works consistently across all three list pages

Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality integrated across multiple views (Token Acquisition, My Contributions, and My Projects)
  * Search queries now synchronized with the URL, enabling users to bookmark and share search results
  * Search state maintained during navigation while preserving existing filter behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->