### PR TITLE
fix: single-signature chained transaction for campaign creation

### DIFF
--- a/src/lib/ergo/actions/submit.ts
+++ b/src/lib/ergo/actions/submit.ts
@@ -1,3 +1,4 @@
+// SINGLE-SIGNATURE CHAINED TX FIX
 
 import {
     OutputBuilder,
@@ -14,7 +15,7 @@ import { SString } from '../utils';
 import { type contract_version, get_ergotree_hex, mint_contract_address } from '../contract';
 import { createR8Structure, type ConstantContent } from '$lib/common/project';
 import { get_dev_contract_address, get_dev_contract_hash, get_dev_fee } from '../dev/dev_contract';
-import { fetch_token_details, wait_until_confirmation } from '../fetch';
+import { fetch_token_details } from '../fetch';
 import { getCurrentHeight, getChangeAddress, signTransaction, submitTransaction, getUtxos } from 'wallet-svelte-component';
 import {
     validateProjectContent,
@@ -54,55 +55,7 @@ function playBeep(frequency = 1000, duration = 3000) {
     osc.stop(now + 0.55);
 }
 
-async function* mint_tx(title: string, constants: ConstantContent, version: contract_version, amount: number, decimals: number): AsyncGenerator<string, Box, void> {
-    // Get the wallet address (will be the project address)
-    const walletPk = await getChangeAddress();
 
-    // Get the UTXOs from the current wallet to use as inputs
-    const inputs = await getUtxos();
-
-    let outputs: OutputBuilder[] = [
-        new OutputBuilder(
-            SAFE_MIN_BOX_VALUE, // Minimum value in ERG that a box can have
-            mint_contract_address(constants, version)
-        )
-            .mintToken({
-                amount: BigInt(amount),
-                name: title + " APT",    // A pro for use IDT (identity token) and TFT (temporal funding token) with the same token is that the TFT token that the user holds has the same id than the project.  This allows the user to verify the exact project in case than two projects has the same name.
-                decimals: decimals,
-                description: "Temporal-funding Token for the " + title + " project."
-            })
-    ]
-
-    // Building the unsigned transaction
-    const unsignedTransaction = await new TransactionBuilder(await getCurrentHeight())
-        .from(inputs)                          // Inputs coming from the user's UTXOs
-        .to(outputs)                           // Outputs (the new project box)
-        .sendChangeTo(walletPk)                // Send change back to the wallet
-        .payFee(RECOMMENDED_MIN_FEE_VALUE)     // Pay the recommended minimum fee
-        .build()                               // Build the transaction
-        .toEIP12Object();                      // Convert the transaction to an EIP-12 compatible object
-
-    yield "Please sign the mint transaction...";
-
-    // Sign the transaction
-    const signedTransaction = await signTransaction(unsignedTransaction);
-
-    // Send the transaction to the Ergo network
-    const transactionId = await submitTransaction(signedTransaction);
-
-    console.log("Mint tx id: " + transactionId);
-
-    yield "Waiting for mint confirmation... (this may take a few minutes)";
-
-    let box = await wait_until_confirmation(transactionId);
-    if (box == null) {
-        alert("Mint tx failed.")
-        throw new Error("Mint tx failed.")
-    }
-
-    return box
-}
 
 // Function to submit a project to the blockchain
 export async function* submit_project(
@@ -151,86 +104,88 @@ export async function* submit_project(
     let token_data = await get_token_data(token_id);
     let id_token_amount = token_data["amount"] + 1;
 
-    // Build the mint tx.
-    yield "Preparing mint transaction...";
-    const mintGen = mint_tx(title, addressContent, version, id_token_amount, token_data["decimals"]);
-    let mintResult = await mintGen.next();
-    while (!mintResult.done) {
-        yield mintResult.value;
-        mintResult = await mintGen.next();
+
+
+const inputs = await getUtxos();
+
+
+const r4Hex = SPair(SBool(is_timestamp_limit), SLong(BigInt(blockLimit))).toHex();
+const r5Hex = SLong(BigInt(minimumSold)).toHex();
+const r6Hex = SColl(SLong, [BigInt(0), BigInt(0), BigInt(0)]).toHex();
+const r7Hex = SLong(BigInt(exchangeRate)).toHex();
+const r8Hex = createR8Structure(addressContent).toHex();
+const r9Hex = SString(projectContent);
+
+// Calculate register sizes using utility functions
+const registerSizes = estimateRegisterSizes(r4Hex, r5Hex, r6Hex, r7Hex, r8Hex, r9Hex);
+
+const ergoTreeAddress = get_ergotree_hex(addressContent, version);
+
+// Estimate total box size
+const totalEstimatedSize = estimateTotalBoxSize(
+    ergoTreeAddress.length,
+    3, // number of tokens (project_id, pft_token_id, and possibly base_token_id)
+    registerSizes
+);
+
+
+let minRequiredValue = BOX_VALUE_PER_BYTE * BigInt(totalEstimatedSize);
+if (minRequiredValue < SAFE_MIN_BOX_VALUE) {
+    minRequiredValue = SAFE_MIN_BOX_VALUE;
+}
+
+
+
+const mintOutput = new OutputBuilder(
+  SAFE_MIN_BOX_VALUE,
+  mint_contract_address(addressContent, version)
+).mintToken({
+  amount: BigInt(id_token_amount),
+  name: title + " APT",
+  decimals: token_data.decimals,
+  description: "Temporal-funding Token for the " + title + " project."
+});
+
+// Token ID generated INSIDE the same transaction
+const projectTokenId = mintOutput.minting.tokenId;
+
+// 🔹 Output 2: Campaign box (uses minted token)
+const campaignOutput = new OutputBuilder(
+  minRequiredValue,
+  ergoTreeAddress
+)
+  .addTokens([
+    {
+      tokenId: projectTokenId,
+      amount: BigInt(id_token_amount)
+    },
+    {
+      tokenId: token_id,
+      amount: BigInt(token_amount)
     }
-    let mint_box = mintResult.value;
+  ])
+   .setAdditionalRegisters({
+    R4: r4Hex,
+    R5: r5Hex,
+    R6: r6Hex,
+    R7: r7Hex,
+    R8: r8Hex,
+    R9: r9Hex
+  });
+// Building the unsigned transaction
+const unsignedTransaction = await new TransactionBuilder(await getCurrentHeight())
+.from(inputs)                          // Inputs coming from the user's UTXOs
+.to([mintOutput, campaignOutput])                          // Outputs (the new project box)
+.sendChangeTo(walletPk)                // Send change back to the wallet
+.payFee(RECOMMENDED_MIN_FEE_VALUE)     // Pay the recommended minimum fee
+.build()                               // Build the transaction
+.toEIP12Object();                      // Convert the transaction to an EIP-12 compatible object
 
-    let project_id = mint_box.assets[0].tokenId;
-
-    if (project_id === null) { alert("Token minting failed!"); return null; }
-
-    // Get the UTXOs from the current wallet to use as inputs
-    const inputs = [mint_box, ...await window.ergo!.get_utxos()];
-
-    const r4Hex = SPair(SBool(is_timestamp_limit), SLong(BigInt(blockLimit))).toHex();
-    const r5Hex = SLong(BigInt(minimumSold)).toHex();
-    const r6Hex = SColl(SLong, [BigInt(0), BigInt(0), BigInt(0)]).toHex();
-    const r7Hex = SLong(BigInt(exchangeRate)).toHex();
-    const r8Hex = createR8Structure(addressContent).toHex();
-    const r9Hex = SString(projectContent);
-
-    // Calculate register sizes using utility functions
-    const registerSizes = estimateRegisterSizes(r4Hex, r5Hex, r6Hex, r7Hex, r8Hex, r9Hex);
-
-    const ergoTreeAddress = get_ergotree_hex(addressContent, version);
-
-    // Estimate total box size
-    const totalEstimatedSize = estimateTotalBoxSize(
-        ergoTreeAddress.length,
-        3, // number of tokens (project_id, pft_token_id, and possibly base_token_id)
-        registerSizes
-    );
-
-
-    let minRequiredValue = BOX_VALUE_PER_BYTE * BigInt(totalEstimatedSize);
-    if (minRequiredValue < SAFE_MIN_BOX_VALUE) {
-        minRequiredValue = SAFE_MIN_BOX_VALUE;
-    }
-
-    // Building the project output
-    let outputs: OutputBuilder[] = [new OutputBuilder(
-        minRequiredValue,                       // Minimum value in ERG that a box can have
-        ergoTreeAddress        // Address of the project contract
-    )
-        .addTokens([
-            {
-                tokenId: project_id,
-                amount: BigInt(id_token_amount)     // The mint contract force to spend all the id_token_amount
-            },
-            {
-                tokenId: token_id ?? "",
-                amount: token_amount.toString()
-            }
-        ])
-        .setAdditionalRegisters({
-            R4: r4Hex,
-            R5: r5Hex,
-            R6: r6Hex,
-            R7: r7Hex,
-            R8: r8Hex,
-            R9: r9Hex
-        })];
-
-    // Building the unsigned transaction
-    const unsignedTransaction = await new TransactionBuilder(await getCurrentHeight())
-        .from(inputs)                          // Inputs coming from the user's UTXOs
-        .to(outputs)                           // Outputs (the new project box)
-        .sendChangeTo(walletPk)                // Send change back to the wallet
-        .payFee(RECOMMENDED_MIN_FEE_VALUE)     // Pay the recommended minimum fee
-        .build()                               // Build the transaction
-        .toEIP12Object();                      // Convert the transaction to an EIP-12 compatible object
-
-    try {
-        playBeep();
-    } catch (error) {
-        console.error('Error executing play beep:', error);
-    }
+try {
+    playBeep();
+} catch (error) {
+    console.error('Error executing play beep:', error);
+}
 
     yield "Please sign the project transaction...";
 


### PR DESCRIPTION
### What this fixes
- Removes two-step campaign creation flow
- Mints APT/IDT token and creates campaign box in a single transaction
- User signs only once

### Technical details
- Uses chained outputs inside one FleetSDK transaction
- Campaign box consumes token minted earlier in the same transaction
- No confirmation wait or second signature required

Closes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined the project minting and campaign creation process into a single, combined transaction for improved efficiency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->