### PR TITLE
feat: GitHub Pages deployment with dynamic base path and esRawPlugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages & Package
+name: Deploy to GitHub Pages
 
 on:
   push:
@@ -11,38 +11,32 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+        env:
+          NODE_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build site
-        run: npm run build
-        env:
-          NODE_ENV: production
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: build
-
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,20 +1,23 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/kit/vite';
 
+const base = process.env.BASE_PATH ?? (process.env.NODE_ENV === 'production'
+	? `/${(process.env.GITHUB_REPOSITORY ?? '').split('/')[1] ?? ''}`.replace(/\/$/, '')
+	: '');
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
-	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 
 	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter(),
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: 'index.html'
+		}),
 		paths: {
-            base: '',
-        }
+			base
+		}
 	}
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,32 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { readFileSync } from 'node:fs';
 import path from "path";
 
-export default defineConfig({
-	plugins: [sveltekit()],
-  	resolve: {
-    		alias: {
-      			$lib: path.resolve("./src/lib"),
-    		},
-  	}
-});
+function esRawPlugin() {
+	return {
+		name: 'es-raw',
+		enforce: 'pre' as const,
+		load(id: string) {
+			if (!id.endsWith('.es')) return null;
+			const source = readFileSync(id, 'utf-8');
+			return `export default ${JSON.stringify(source)};`;
+		}
+	};
+}
 
-const config = {
-	// …
-	ssr: {
-	  noExternal: ['three']
-	}
-  }
+export default defineConfig({
+	plugins: [esRawPlugin(), sveltekit()],
+	resolve: {
+		alias: {
+			$lib: path.resolve("./src/lib"),
+		},
+	},
+	optimizeDeps: {
+		esbuildOptions: {
+			loader: {
+				'.es': 'text',
+			},
+		},
+	},
+});


### PR DESCRIPTION
## Changes

This PR updates the project to follow the standardized GitHub Pages + reusable library deployment guide.

### What changed:

1. **`svelte.config.js`** — Added dynamic `BASE_PATH` support so the app works correctly when deployed to GitHub Pages (under a subpath like `/BenefactionPlatform-Ergo`). Uses `GITHUB_REPOSITORY` env var automatically in CI. Added explicit `adapter-static` configuration with `pages`, `assets`, and `fallback: 'index.html'` for SPA routing support.

2. **`vite.config.ts`** — Added `esRawPlugin()` for loading `.es` ErgoScript contract files (dev_fee.es, contract_v1_0.es, contract_v1_1.es, contract_v2.es, mint_idt.es) as raw text at build time. Added `.es` esbuild loader config. Cleaned up unused dangling `const config` block. Preserved existing aliases.

3. **`.github/workflows/deploy.yml`** — Updated to follow the standardized template with separate `build` and `deploy` jobs. Removed the combined build-and-deploy job. Added `cancel-in-progress: false` for safer deployments.

4. **`src/routes/+layout.ts`** — Already had `ssr = false` and `prerender = true` ✅

### How it works:
- In CI, `GITHUB_REPOSITORY` is set automatically (e.g. `StabilityNexus/BenefactionPlatform-Ergo`), so the base path becomes `/BenefactionPlatform-Ergo`
- In local dev, the base path is empty (no subpath)
- Can be overridden with `BASE_PATH` env var if needed
- The `esRawPlugin` ensures `.es` contract files are importable as strings in the application code

### Build verified ✅
Tested locally — `npm run build` completes successfully with all changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow with improved build and deploy stage separation
  * Enhanced configuration flexibility for different deployment environments and URL paths
  * Improved build asset handling and optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->