### PR TITLE
fix: detect custom domain (CNAME) and use empty base path

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,9 +1,15 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/kit/vite';
+import { existsSync } from 'node:fs';
 
-const base = process.env.BASE_PATH ?? (process.env.NODE_ENV === 'production'
-	? `/${(process.env.GITHUB_REPOSITORY ?? '').split('/')[1] ?? ''}`.replace(/\/$/, '')
-	: '');
+// If a CNAME file exists (custom domain), base path must be empty.
+// Otherwise, derive base from the repo name for GitHub Pages sub-path hosting.
+const hasCustomDomain = existsSync('static/CNAME');
+const base = process.env.BASE_PATH ?? (hasCustomDomain
+	? ''
+	: (process.env.NODE_ENV === 'production'
+		? `/${(process.env.GITHUB_REPOSITORY ?? '').split('/')[1] ?? ''}`.replace(/\/$/, '')
+		: ''));
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
## Problem
After merging the GitHub Pages deploy PR (#169), all dynamic chunk imports return 404 errors. The site at `ergo.bene.stability.nexus` tries to load assets from `/BenefactionPlatform-Ergo/_app/...` but with a custom domain, assets are served from the root.

## Root Cause
`svelte.config.js` always derived the base path from `GITHUB_REPOSITORY` (`/BenefactionPlatform-Ergo`), but when a custom domain is configured (CNAME file exists), the base path must be empty.

## Fix
Added CNAME file detection in `svelte.config.js`:
- If `static/CNAME` exists → base path is empty (`""`)
- If no CNAME → base path derived from repo name (for standard GitHub Pages sub-path hosting)

Build verified with `NODE_ENV=production` — all paths now correctly resolve to `/` root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration logic to better detect custom domains and dynamically adjust path handling based on deployment environment, supporting custom domains, environment variables, and GitHub Pages deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->