### PR TITLE
Fix: do not let isWithdrawFunds terminate while the contract is recreated (#78)

### DIFF
--- a/contracts/bene_contract/contract_v2.es
+++ b/contracts/bene_contract/contract_v2.es
@@ -432,8 +432,12 @@
       val endOrReplicate = {
         val allFundsWithdrawn = if (isERGBase) extractedBaseAmount == selfValue else (extractedBaseAmount == getBaseTokenAmount(SELF))
         val allTokensWithdrawn = SELF.tokens.exists({(pair: (Coll[Byte], Long)) => pair._1 == pftTokenId}) == false
+        // The contract may only be considered finished if it is not recreated anywhere in the
+        // transaction. Checking OUTPUTS(0) alone (which is what isSelfReplication does) would let a
+        // spender put a copy at another index, where none of the replication guards are evaluated.
+        val ended = OUTPUTS.exists({(box: Box) => box.propositionBytes == SELF.propositionBytes}) == false
 
-        isSelfReplication || allFundsWithdrawn && allTokensWithdrawn
+        isSelfReplication || (ended && allFundsWithdrawn && allTokensWithdrawn)
       }
 
       val constants = allOf(Coll(


### PR DESCRIPTION
Re #78, and the fix for the failing test in #174.

`isWithdrawFunds` could terminate the contract while a copy of it was recreated in the same transaction, as long as that copy was not at `OUTPUTS(0)`. Everywhere else the replication guards are written as `!isReplicationBoxPresent || (...)`, and `isReplicationBoxPresent` only inspects `OUTPUTS(0)`, so a clone at another index escaped all of them and could carry any registers the spender wanted - including their own address as the project owner.

The change is the check `isWithdrawUnsoldTokens` already makes:

```
val ended = OUTPUTS.exists({(box: Box) => box.propositionBytes == SELF.propositionBytes}) == false
isSelfReplication || (ended && allFundsWithdrawn && allTokensWithdrawn)
```

A legitimate full withdrawal creates no box with the contract script, so `ended` holds and it still passes. A partial withdrawal goes through `isSelfReplication` as before and is untouched.

## Verification

- `tests/contracts/replication_guard.test.ts` (from #174): fails on `main`, passes with this change.
- `tests/contracts/withdraw_funds.test.ts`: 18/18.
- `tests/contracts/withdraw_unsold_tokens.test.ts`: 15/16 - the one red test (`should allow fully withdrawing unsold PFT tokens`, ERG mode) is already red on unmodified `main`; I re-ran it against the untouched contract to be certain it is not caused by this change.

Note that running any of this locally needs the `wallet-svelte-component` workaround described in #174.