### PR TITLE
fix(ui): refuse to display a campaign when two boxes claim its id

### DIFF
--- a/src/lib/common/load_by_id.ts
+++ b/src/lib/common/load_by_id.ts
@@ -1,17 +1,34 @@
-import { type Project } from "./project";
-import { project_detail } from "./store";
+import { get } from "svelte/store";
+import { project_detail, project_id_conflicts, project_load_error } from "./store";
 import { fetchProjectById } from "$lib/ergo/fetch";
 
 export async function loadProjectById(projectId: string) {
+    project_load_error.set(null);
+
     try {
         const project = await fetchProjectById(projectId);
-        
+
         if (!project) {
+            const conflictingBoxes = get(project_id_conflicts).get(projectId);
+
+            if (conflictingBoxes) {
+                // More than one unspent box claims this id. One of them is an impersonation and
+                // nothing on chain says which, so the campaign is not shown at all. See #176.
+                project_load_error.set(
+                    `This campaign cannot be displayed safely: ${conflictingBoxes.length} different boxes ` +
+                    `claim the id ${projectId}, so there is no way to tell the real one from an imitation. ` +
+                    `Do not send funds to it. Boxes: ${conflictingBoxes.join(", ")}.`
+                );
+                return;
+            }
+
             throw new Error(`Project with ID ${projectId} not found.`);
         }
-        
+
         project_detail.set(project);
     } catch (error) {
-        console.error(`Failed to load project: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        project_load_error.set(message);
+        console.error(`Failed to load project: ${message}`);
     }
 }

--- a/src/lib/common/store.ts
+++ b/src/lib/common/store.ts
@@ -15,6 +15,14 @@ export const projects = writable<{ data: Map<string, Project>, last_fetch: numbe
     data: new Map(),
     last_fetch: 0
 })
+// Project ids for which more than one unspent box claims to be the campaign, mapped to the
+// competing box ids. While an id is listed here the UI must refuse to display it: there is no way
+// to tell the real box from an imitation, so picking one would mean picking the attacker's.
+export const project_id_conflicts = writable<Map<string, string[]>>(new Map());
+
+// Reason why the campaign requested through the URL could not be displayed, if any.
+export const project_load_error = writable<string | null>(null);
+
 export const user_tokens = writable<Map<string, number>>(new Map());
 export const explorer_uri = writable<string | null>("https://api.ergoplatform.com");
 export const web_explorer_uri_tx = writable<string>(DEFAULT_WEB_EXPLORER_URI_TX);

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -3,7 +3,7 @@ import { type ConstantContent, type Project, type TokenEIP4, getConstantContent,
 import { ErgoPlatform } from "./platform";
 import { hexToUtf8 } from "./utils";
 import { type contract_version, get_template_hash } from "./contract";
-import { explorer_uri, projects } from "$lib/common/store";
+import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
 import { get } from "svelte/store";
 import { get_dev_contract_hash, get_dev_fee } from "./dev/dev_contract";
 
@@ -30,6 +30,39 @@ const CACHE_DURATION_MS = 1000 * 60 * 5;
 
 // Variable to track an ongoing request
 let inFlightFetch: Promise<Map<string, Project>> | null = null;
+
+/**
+ * Two unspent boxes can claim to be the same campaign at the same time.
+ *
+ * A project is identified by `tokens(0)` of the contract box, which is the APT: a fungible token
+ * with `amount = PFT emission + 1` that circulates to buyers by design, not a singleton NFT. The
+ * contract ErgoTree carries no per-project constants either, so it is identical for every campaign
+ * and anyone can reproduce it. Together that means anyone holding one unit of a campaign's APT can
+ * build a box that parses as that same campaign, with an owner, an exchange rate and counters of
+ * their choosing.
+ *
+ * When that happens there is nothing in the box that says which one is real, so the UI must not
+ * pick: `fetchProjectsFromBlockchain` used to keep whichever box the explorer returned last, and
+ * `fetchProjectById` whichever parsed first. Both are now recorded as conflicts and hidden.
+ *
+ * The real fix is a singleton NFT plus canonical-box resolution by lineage. See #176.
+ */
+function recordConflict(projectId: string, boxIds: string[]) {
+    console.error(
+        `Project ${projectId} is claimed by ${boxIds.length} unspent boxes: ${boxIds.join(", ")}. ` +
+        `Refusing to display it, one of them is an impersonation.`
+    );
+    project_id_conflicts.update((current) => new Map(current).set(projectId, boxIds));
+}
+
+function clearConflict(projectId: string) {
+    project_id_conflicts.update((current) => {
+        if (!current.has(projectId)) return current;
+        const next = new Map(current);
+        next.delete(projectId);
+        return next;
+    });
+}
 
 function hasValidSigmaTypes(additionalRegisters: any, version: contract_version): boolean {
     if (!additionalRegisters) return false;
@@ -141,6 +174,13 @@ export async function fetchProjectsFromBlockchain() {
 
     const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
 
+    // Box id seen for each project id during THIS sweep. It cannot be read off the `projects`
+    // store: a non-forced refetch keeps the previous entries, whose box ids are legitimately
+    // outdated after any action on the campaign, and comparing against them would report every
+    // active campaign as a conflict.
+    const boxIdByProject = new Map<string, string>();
+    const conflicts = new Map<string, string[]>();
+
     try {
         for (const version of versions) {
             moreDataAvailable = true;
@@ -182,15 +222,33 @@ export async function fetchProjectsFromBlockchain() {
 
                 for (const e of json_data.items) {
                     const project = await parseProjectBox(e, version);
-                    if (project) {
+                    if (!project) continue;
+
+                    const knownBoxId = boxIdByProject.get(project.project_id);
+                    if (knownBoxId !== undefined && knownBoxId !== project.box.boxId) {
+                        const boxIds = conflicts.get(project.project_id) ?? [knownBoxId];
+                        if (!boxIds.includes(project.box.boxId)) boxIds.push(project.box.boxId);
+                        conflicts.set(project.project_id, boxIds);
+
+                        // Drop the one already listed instead of replacing it: neither can be trusted.
                         const current = get(projects).data;
-                        current.set(project.project_id, project)
+                        current.delete(project.project_id);
                         projects.set({ data: current, last_fetch: get(projects).last_fetch });
+                        continue;
                     }
+
+                    boxIdByProject.set(project.project_id, project.box.boxId);
+                    const current = get(projects).data;
+                    current.set(project.project_id, project)
+                    projects.set({ data: current, last_fetch: get(projects).last_fetch });
                 }
                 params.offset += params.limit;
             }
         }
+
+        // This sweep covers every unspent box carrying a campaign contract template, so it is
+        // authoritative for the listing: replace the previous verdict rather than accumulating.
+        project_id_conflicts.set(conflicts);
     } catch (error) {
         console.error('Error while making the POST request:', error);
         return new Map(); // Returns empty map in case of error
@@ -218,18 +276,32 @@ export async function fetchProjectById(projectId: string): Promise<Project | nul
              return null;
          }
 
-         // Iterate through all items to find a valid project box
+         // Parse every box that claims to be this project, not just the first one. Returning the
+         // first match would hand the page to whichever box the explorer happened to list first.
+         const candidates: Project[] = [];
          for (const box of json_data.items) {
              for (const v of versions) {
-                 // Try to parse with each version. 
+                 // Try to parse with each version.
                  const p = await parseProjectBox(box, v);
                  if (p) {
                      console.log(`Successfully parsed project ${projectId} with version ${v}`);
-                     return p;
+                     candidates.push(p);
+                     break;
                  }
              }
          }
-         
+
+         if (candidates.length > 1) {
+             recordConflict(projectId, candidates.map((p) => p.box.boxId));
+             return null;
+         }
+
+         clearConflict(projectId);
+
+         if (candidates.length === 1) {
+             return candidates[0];
+         }
+
          console.warn(`Failed to parse project ${projectId} with any version`);
          return null;
 

--- a/src/routes/App.svelte
+++ b/src/routes/App.svelte
@@ -6,6 +6,7 @@
         balance,
         network,
         project_detail,
+        project_load_error,
         project_token_amount,
         temporal_token_amount,
         timer,
@@ -131,6 +132,7 @@
         timer.set({ countdownInterval: 0, target: 0 });
 
         project_detail.set(null);
+        project_load_error.set(null);
         temporal_token_amount.set(null);
         project_token_amount.set(null);
 
@@ -396,6 +398,12 @@
         </div>
     {:else}
         {#if $project_detail === null}
+            {#if $project_load_error}
+                <div class="project-load-error" role="alert">
+                    <strong>This campaign could not be opened</strong>
+                    <p>{$project_load_error}</p>
+                </div>
+            {/if}
             {#if activeTab === "acquireTokens"}
                 <TokenAcquisition bind:searchQuery/>
             {/if}
@@ -489,6 +497,25 @@
 <SettingsModal bind:open={showSettingsModal} />
 
 <style>
+    .project-load-error {
+        max-width: 46rem;
+        margin: 1.5rem auto;
+        padding: 1rem 1.25rem;
+        border: 1px solid rgba(239, 68, 68, 0.4);
+        border-radius: 0.5rem;
+        background: rgba(239, 68, 68, 0.08);
+        color: rgb(185, 28, 28);
+    }
+
+    :global(.dark) .project-load-error {
+        color: rgb(252, 165, 165);
+    }
+
+    .project-load-error p {
+        margin: 0.5rem 0 0;
+        overflow-wrap: anywhere;
+    }
+
     :global(html) {
         height: 100%;
         scroll-behavior: smooth;

--- a/src/routes/ProjectList.svelte
+++ b/src/routes/ProjectList.svelte
@@ -2,7 +2,7 @@
     import ProjectCard from "./ProjectCard.svelte";
     import ProjectCardSkeleton from "./ProjectCardSkeleton.svelte";
     import { type Project } from "$lib/common/project";
-    import { projects } from "$lib/common/store";
+    import { projects, project_id_conflicts } from "$lib/common/store";
     import { fetchProjects } from "$lib/ergo/fetch";
     import * as Alert from "$lib/components/ui/alert";
     import { Loader2, Search, Filter } from "lucide-svelte";
@@ -272,6 +272,19 @@
             <Alert.Description class="text-center"
                 >{errorMessage}</Alert.Description
             >
+        </Alert.Root>
+    {/if}
+
+    {#if $project_id_conflicts.size > 0}
+        <Alert.Root
+            class="my-4 border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+        >
+            <Alert.Description class="text-center">
+                {$project_id_conflicts.size}
+                {$project_id_conflicts.size === 1 ? "campaign is" : "campaigns are"}
+                hidden: more than one box claims the same campaign id, so the real
+                one cannot be told apart from an imitation.
+            </Alert.Description>
         </Alert.Root>
     {/if}
 


### PR DESCRIPTION
Stop-gap for the impersonation vector described in #176, while the real fix (singleton NFT + canonical box resolution by lineage) is designed.

## The problem

A campaign is identified by `tokens(0)` of the contract box — the APT. That token is fungible (`amount = PFT emission + 1`) and circulates to buyers by design, and the contract ErgoTree carries no per-project constants, so it is identical for every campaign and anyone can reproduce it. Anyone holding **one unit** of a campaign's APT can build a box that parses as that same campaign, with an owner, an exchange rate and counters of their choosing.

The UI then had to pick between two boxes claiming the same id, and picked silently:

- `fetchProjectsFromBlockchain` did `current.set(project.project_id, project)`, so whichever box the explorer returned last won.
- `fetchProjectById` returned the first box that parsed.

Neither order is under our control, so a victim opening a shared campaign link could be shown the attacker's box.

## What this PR does

Detects the collision in both paths and refuses to display the campaign:

- **`fetchProjectById`** now parses every box claiming the id instead of returning on the first match. More than one valid box → the campaign is recorded as a conflict and `null` is returned.
- **`fetchProjectsFromBlockchain`** tracks the box id seen per campaign during the sweep. A second, different box for the same id removes the campaign from the listing and records the conflict.
- **New store `project_id_conflicts`** (`project_id → competing box ids`) plus `project_load_error`.
- **`App.svelte`** shows an explicit error where the campaign page would have been. Until now `loadProjectById` swallowed every failure into a `console.error` and the user just saw the campaign listing.
- **`ProjectList.svelte`** shows a banner stating how many campaigns are hidden and why.

The box id comparison is deliberately scoped to a single sweep rather than compared against the `projects` store: a non-forced refetch keeps the previous entries, whose box ids are legitimately outdated after any action on a campaign, and comparing against those would flag every active campaign as a conflict.

## What this PR does NOT do

Worth being explicit, because the title could be read as more than it is:

1. **It does not close the post-termination clone.** Once the real box is spent, the imitation is the *only* box claiming the id, there is no collision to detect, and it is displayed as the campaign. That case needs lineage resolution (#176), not duplicate detection.
2. **It does not verify the box script.** `parseProjectBox` checks register sigma types and that `dev_hash` / `dev_fee` match the platform's, but never checks that the box is locked by a campaign contract at all. A box under the attacker's own P2PK with the right registers parses as a campaign. This PR turns that into a detected conflict while the real box lives, but it does not reject it outright. Adding a template-hash check is a natural follow-up — left out here because it cannot be verified without running the app, and getting it wrong would drop every legitimate campaign off the site.
3. **It converts impersonation into denial of service.** Anyone can now hide any campaign from the platform by creating a box that claims its id. That is a deliberate trade: a hidden campaign is recoverable, funds sent to an attacker are not. It is also another reason not to treat this as the fix.

## Testing

**Not run.** There is no Node toolchain in the environment where this was written, so neither the app nor the test suite was executed — and per #174 `vitest` does not currently start on a clean checkout anyway. The change is small and confined to two fetch paths plus two presentational blocks, but it needs a manual pass before merging:

- a campaign with a single box still opens by URL and still appears in the listing;
- a campaign refetched after an action (new box id) is **not** reported as a conflict — this is the regression to watch for;
- with two boxes claiming one id, the campaign page shows the error and the listing shows the banner.

Refs #176.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detects duplicate campaign IDs and hides affected campaigns to prevent unsafe loading.
  * Reports clearer project-loading errors when campaigns cannot be safely displayed.
  * Clears stale loading errors when switching views or retrying.

* **User Interface**
  * Added alerts explaining duplicate campaign conflicts and hidden campaigns.
  * Added styled error messages for project-loading failures, including dark-theme support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->