### PR TITLE
Let vitest collect: stub wallet-svelte-component

### DIFF
--- a/tests/stubs/wallet-svelte-component.ts
+++ b/tests/stubs/wallet-svelte-component.ts
@@ -1,0 +1,11 @@
+// Stub for wallet-svelte-component.
+//
+// The published package ships Svelte components and extensionless ESM imports that Node cannot
+// resolve, so vitest dies during collection with ERR_MODULE_NOT_FOUND before running a single
+// test - including the tests already in the repo. It reaches the test run only transitively,
+// through $lib, and nothing under tests/ touches it, so aliasing it to this empty module in
+// vitest.config.ts is enough to let the suite run.
+//
+// If a test ever does need the real component, this stub is the place to give it a surface
+// rather than removing the alias, which would put the collection error back.
+export default {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   resolve: {
     alias: {
       $lib: path.resolve(__dirname, './src/lib'),
+      // wallet-svelte-component ships .svelte files and extensionless ESM imports that Node
+      // cannot resolve, so vitest dies during collection - before running a single test,
+      // including the ones already in the repo. It is pulled in transitively by $lib and no
+      // test touches it, so it is stubbed out here.
+      'wallet-svelte-component': path.resolve(__dirname, './tests/stubs/wallet-svelte-component.ts'),
     },
   },
 });


### PR DESCRIPTION
As offered in #174. Two lines in `vitest.config.ts` plus the stub they point at.

## What happens today

`npm test` on a clean checkout of `main` does not run a single test:

```
Cannot find module '.../node_modules/wallet-svelte-component/dist/components/ui/button.js'
ERR_MODULE_NOT_FOUND

 Test Files  10 failed (10)
      Tests  no tests
```

The package ships `.svelte` files and extensionless ESM imports that Node cannot resolve, and vitest dies during **collection** - so it takes down the tests already in the repo, not just new ones. It reaches the test run only transitively through `$lib`; nothing under `tests/` imports it.

## After

```
 Test Files  4 failed | 6 passed (10)
      Tests  8 failed | 115 passed (123)
```

## About those 8

None of them are caused by this change - it only decides whether tests get to run at all. On `main`, with this alias applied and nothing else:

- `refund_tokens.test.ts` - 4, all the **Timestamp** variants (ERG and SigUSD): "should allow refunding APT tokens after deadline when minimum not reached" and "should allow multiple sequential refunds and update refund counter cumulatively"
- `withdraw_unsold_tokens.test.ts` - 1: "should allow fully withdrawing unsold PFT tokens" (ERG mode, complex owner script authorization)
- `add_tokens.test.ts` - 2: "should allow project owner to add more PFT tokens", both modes

That is 7. The 8th is `replication_guard.test.ts` from #174, which is red on purpose until #175 or its v3 successor lands.

I had reported only one red test in #174, because it was the only one I had run at the time. Seven is the real number, and since you said a red test on `main` has to be fixed before anything else is merged, it seemed worth putting the list somewhere findable rather than leaving it in a PR comment. Happy to open an issue for them, or to look into them - tell me which you would rather.

## Note

The alias is a workaround, not a fix for the package. If a test ever needs the real component, the stub is the place to give it a surface; removing the alias puts the collection error back.