### PR TITLE
Canonical box resolution by lineage, and a legacy-contract badge (#176)

### DIFF
--- a/src/lib/common/project.ts
+++ b/src/lib/common/project.ts
@@ -84,6 +84,19 @@ export interface Project {
     constants: ConstantContent
 }
 
+/**
+ * Whether a project runs on an older contract than the one the platform deploys today.
+ *
+ * Written as a comparison against `last_version` rather than a list of old versions, so that
+ * publishing a new contract marks its predecessor without anyone having to remember to come back
+ * here. It matters for #176: the versions this returns true for are the ones with no on-chain
+ * identity beyond a circulating token, so a campaign on one is worth a second look before it is
+ * funded.
+ */
+export function is_legacy_version(project: Project): boolean {
+    return project.version !== project.platform.last_version;
+}
+
 export async function is_ended(project: Project): Promise<boolean> {
     if (project.is_timestamp_limit) {
         // In timestamp mode, compare with current time

--- a/src/lib/components/LegacyContractBadge.svelte
+++ b/src/lib/components/LegacyContractBadge.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import { badgeVariants } from "$lib/components/ui/badge";
+    import { is_legacy_version, type Project } from "$lib/common/project";
+
+    export let project: Project;
+    /** Compact form for cards, where the row is already crowded. */
+    export let compact: boolean = false;
+
+    $: isLegacy = is_legacy_version(project);
+    $: label = project.version.replace("_", ".");
+
+    const explanation =
+        "This campaign runs on an older version of the contract. Check the project's " +
+        "own channels before contributing, and prefer campaigns on the current contract.";
+</script>
+
+{#if isLegacy}
+    <a
+        href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"
+        target="_blank"
+        rel="noopener noreferrer"
+        title={explanation}
+        class="{badgeVariants({
+            variant: 'outline',
+        })} legacy-badge"
+    >
+        {compact ? `Legacy ${label}` : `Legacy contract ${label}`}
+    </a>
+{/if}
+
+<style>
+    .legacy-badge {
+        border-color: rgba(234, 179, 8, 0.6);
+        color: rgb(202, 138, 4);
+        background-color: rgba(234, 179, 8, 0.1);
+        white-space: nowrap;
+    }
+
+    :global(.dark) .legacy-badge {
+        color: rgb(250, 204, 21);
+    }
+</style>

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -6,6 +6,7 @@ import { type contract_version, get_template_hash } from "./contract";
 import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
 import { get } from "svelte/store";
 import { get_dev_contract_hash, get_dev_fee } from "./dev/dev_contract";
+import { resolveCanonicalBox } from "./lineage";
 
 const expectedSigmaTypesV1 = {
     R4: 'SInt',
@@ -62,6 +63,33 @@ function clearConflict(projectId: string) {
         next.delete(projectId);
         return next;
     });
+}
+
+/**
+ * Which of several boxes claiming one project id descends from the mint, or null when that cannot
+ * be established.
+ *
+ * This is the "canonical-box resolution by lineage" the note above points at. It answers the
+ * question the box itself cannot: the APT says which campaign a box claims to be, and the walk
+ * from the mint says which box the campaign actually is. Only called on an actual collision, so
+ * the extra explorer calls are not paid for on every project of every sweep.
+ */
+async function resolveByLineage<T extends { box: { boxId: string } }>(
+    projectId: string,
+    candidates: T[]
+): Promise<T | null> {
+    try {
+        const { box, ended } = await resolveCanonicalBox(projectId);
+        if (ended) {
+            console.warn(`Project ${projectId} has ended on chain; the boxes claiming it are leftovers`);
+        }
+        // With no canonical box - ended, or not resolvable - `box?.boxId` is undefined and matches
+        // no candidate, which is the answer wanted in both cases: none of these is the campaign.
+        return candidates.find((c) => c.box.boxId === box?.boxId) ?? null;
+    } catch (error) {
+        console.warn(`Could not resolve the lineage of ${projectId}:`, error);
+        return null;
+    }
 }
 
 function hasValidSigmaTypes(additionalRegisters: any, version: contract_version): boolean {
@@ -180,6 +208,9 @@ export async function fetchProjectsFromBlockchain() {
     // active campaign as a conflict.
     const boxIdByProject = new Map<string, string>();
     const conflicts = new Map<string, string[]>();
+    // The parsed project behind each box id above, so that a collision can be settled in favour of
+    // whichever of the two the lineage points at without parsing it again.
+    const seenThisSweep = new Map<string, Project>();
 
     try {
         for (const version of versions) {
@@ -226,18 +257,33 @@ export async function fetchProjectsFromBlockchain() {
 
                     const knownBoxId = boxIdByProject.get(project.project_id);
                     if (knownBoxId !== undefined && knownBoxId !== project.box.boxId) {
-                        const boxIds = conflicts.get(project.project_id) ?? [knownBoxId];
-                        if (!boxIds.includes(project.box.boxId)) boxIds.push(project.box.boxId);
-                        conflicts.set(project.project_id, boxIds);
+                        const rival = seenThisSweep.get(project.project_id);
+                        const winner = rival
+                            ? await resolveByLineage(project.project_id, [rival, project])
+                            : null;
 
-                        // Drop the one already listed instead of replacing it: neither can be trusted.
                         const current = get(projects).data;
-                        current.delete(project.project_id);
+                        if (winner) {
+                            // The chain settles it: one of them descends from the mint and the
+                            // other does not, so the campaign can be listed instead of hidden.
+                            conflicts.delete(project.project_id);
+                            boxIdByProject.set(project.project_id, winner.box.boxId);
+                            seenThisSweep.set(project.project_id, winner);
+                            current.set(project.project_id, winner);
+                        } else {
+                            const boxIds = conflicts.get(project.project_id) ?? [knownBoxId];
+                            if (!boxIds.includes(project.box.boxId)) boxIds.push(project.box.boxId);
+                            conflicts.set(project.project_id, boxIds);
+
+                            // Drop the one already listed instead of replacing it: neither can be trusted.
+                            current.delete(project.project_id);
+                        }
                         projects.set({ data: current, last_fetch: get(projects).last_fetch });
                         continue;
                     }
 
                     boxIdByProject.set(project.project_id, project.box.boxId);
+                    seenThisSweep.set(project.project_id, project);
                     const current = get(projects).data;
                     current.set(project.project_id, project)
                     projects.set({ data: current, last_fetch: get(projects).last_fetch });
@@ -258,6 +304,26 @@ export async function fetchProjectsFromBlockchain() {
 export async function fetchProjectById(projectId: string): Promise<Project | null> {
     console.log(`Fetching project by ID: ${projectId}`);
     const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
+
+    // This is the page someone reads before sending money, so identity is established from the
+    // chain rather than taken on trust from a circulating token: walk from the mint and see which
+    // box that reaches. Unlike the listing sweep, one campaign is worth the round trips - and the
+    // walk is cached, so a second visit costs one call. See #176.
+    let lineage: { boxId: string | null; ended: boolean } | null = null;
+    try {
+        const { box, ended } = await resolveCanonicalBox(projectId);
+        lineage = { boxId: box?.boxId ?? null, ended };
+    } catch (error) {
+        console.warn(`Could not resolve the lineage of ${projectId}:`, error);
+    }
+
+    if (lineage?.ended) {
+        // The chain that starts at the mint has terminated: whatever still carries this token is
+        // a leftover, not the campaign. This is the #174 shape, where the closing transaction also
+        // left a copy behind.
+        console.warn(`Project ${projectId} has ended on chain; not displaying a leftover box`);
+        return null;
+    }
 
     try {
          const url = get(explorer_uri) + '/api/v1/boxes/unspent/byTokenId/' + projectId;
@@ -291,6 +357,25 @@ export async function fetchProjectById(projectId: string): Promise<Project | nul
              }
          }
 
+         if (lineage?.boxId) {
+             const canonical = candidates.find((p) => p.box.boxId === lineage!.boxId);
+             if (canonical) {
+                 clearConflict(projectId);
+                 return canonical;
+             }
+             // The box the chain points at is not among the unspent ones. Whatever is here
+             // instead is not the campaign, however plausible it parses.
+             if (candidates.length > 1) {
+                 recordConflict(projectId, candidates.map((p) => p.box.boxId));
+             }
+             console.warn(
+                 `The canonical box ${lineage.boxId} of ${projectId} is not among the unspent boxes`
+             );
+             return null;
+         }
+
+         // The lineage could not be resolved at all - no such token, or the explorer did not
+         // answer. Fall back to refusing a tie, which is where this stood before #176.
          if (candidates.length > 1) {
              recordConflict(projectId, candidates.map((p) => p.box.boxId));
              return null;

--- a/src/lib/ergo/lineage.ts
+++ b/src/lib/ergo/lineage.ts
@@ -1,0 +1,179 @@
+import { explorer_uri } from "$lib/common/store";
+import { get } from "svelte/store";
+
+/**
+ * Resolving which box really is a project.
+ *
+ * A project has no verifiable on-chain identity in v1 and v2: it is identified by `tokens(0)` of
+ * the contract box - the APT - and that does not distinguish the real box from an imitation. The
+ * ErgoTree is the same for every v2 project, the APT circulates to buyers by design, and anyone
+ * holding one unit of it can build a box with the same script, the same id and registers of their
+ * choosing. Nothing in the contract stops them; see #176.
+ *
+ * What does distinguish the real box is where it came from. Every project starts as OUTPUTS(0) of
+ * the transaction that spends its mint box, and stays OUTPUTS(0) of every transaction that spends
+ * it afterwards, because the contract requires the replica to sit at index 0. So walking the chain
+ * of OUTPUTS(0) from the mint reaches exactly one box, and an imitation - which was created by
+ * some unrelated transaction, or at an index other than 0 - is never on that path.
+ *
+ * The walk also gets termination right for free. When a campaign closes, the transaction that
+ * spends the project box has a payment box at OUTPUTS(0), not a replica, so the chain ends there
+ * and the project is reported as finished. That includes the #174 case, where a clone was slipped
+ * in at index 2 of the terminating transaction: the clone is not on the path, so it is not the
+ * project, which is the answer we want.
+ *
+ * Cost is one explorer call per action the campaign has had. That is why {@link lineageCache}
+ * exists and why the walk is incremental: a resolved project only has to be walked forward from
+ * where it was left, not from the mint again.
+ */
+
+/** How far the walk will go before giving up, so a malformed chain cannot spin forever. */
+const MAX_CHAIN_LENGTH = 5000;
+
+export interface ExplorerBox {
+    boxId: string;
+    transactionId: string;
+    ergoTree: string;
+    value: number;
+    assets: { tokenId: string; amount: number }[];
+    additionalRegisters: Record<string, any>;
+    [key: string]: any;
+}
+
+export interface LineageResult {
+    /** The live project box, or null when the campaign has ended. */
+    box: ExplorerBox | null;
+    /** Why there is no box, when there is none. */
+    ended: boolean;
+    /** How many transactions were walked. Useful to see the cache working. */
+    steps: number;
+}
+
+interface CacheEntry {
+    /** Last box known to be on the chain. */
+    box: ExplorerBox;
+    /** True when that box was already spent into something that is not a project box. */
+    ended: boolean;
+}
+
+/**
+ * Last known position per project, so the next walk continues instead of restarting.
+ *
+ * Only ever holds boxes that were reached from the mint, so continuing from one cannot put the
+ * walk onto a chain it would not have reached anyway.
+ */
+const lineageCache = new Map<string, CacheEntry>();
+
+export function clearLineageCache(projectId?: string) {
+    if (projectId) lineageCache.delete(projectId);
+    else lineageCache.clear();
+}
+
+async function explorerJson(path: string): Promise<any | null> {
+    const response = await fetch(get(explorer_uri) + path, { method: "GET" });
+    if (!response.ok) return null;
+    return await response.json();
+}
+
+/** The box a token was minted into. For a project id that is the mint contract box. */
+async function mintBoxOf(tokenId: string): Promise<string | null> {
+    const token = await explorerJson("/api/v1/tokens/" + tokenId);
+    return token?.boxId ?? null;
+}
+
+async function boxById(boxId: string): Promise<any | null> {
+    return await explorerJson("/api/v1/boxes/" + boxId);
+}
+
+async function transactionById(txId: string): Promise<any | null> {
+    return await explorerJson("/api/v1/transactions/" + txId);
+}
+
+/**
+ * Whether `box` is the project carried forward, rather than a payment box that happens to sit at
+ * OUTPUTS(0) of the spending transaction.
+ *
+ * The test is that it still holds the project's APT at index 0, which is what the contract's
+ * `sameId` check enforces on every replication. A terminating transaction pays the owner at
+ * OUTPUTS(0) instead, and that box does not carry the APT.
+ */
+function carriesProject(box: ExplorerBox | null | undefined, projectId: string): boolean {
+    return !!box && Array.isArray(box.assets) && box.assets.length > 0 && box.assets[0].tokenId === projectId;
+}
+
+/**
+ * Walk forward from `box` for as long as OUTPUTS(0) of each spending transaction is still the
+ * project. Returns where it stopped.
+ */
+async function walkForward(projectId: string, from: ExplorerBox, alreadySteps: number): Promise<LineageResult> {
+    let current = from;
+    let steps = alreadySteps;
+
+    while (steps < MAX_CHAIN_LENGTH) {
+        const detail = await boxById(current.boxId);
+        if (!detail) {
+            // The explorer could not tell us about this box. Report what we have rather than
+            // inventing a conclusion: the caller can retry, and reporting "ended" here would
+            // wrongly hide a live campaign.
+            return { box: current, ended: false, steps };
+        }
+
+        const spentTx = detail.spentTransactionId;
+        if (!spentTx) {
+            lineageCache.set(projectId, { box: current, ended: false });
+            return { box: current, ended: false, steps };
+        }
+
+        const tx = await transactionById(spentTx);
+        const next = tx?.outputs?.[0];
+        steps += 1;
+
+        if (!carriesProject(next, projectId)) {
+            // The box was spent into something that is not the project: the campaign ended here.
+            lineageCache.set(projectId, { box: current, ended: true });
+            return { box: null, ended: true, steps };
+        }
+
+        current = next;
+    }
+
+    console.warn(`Lineage walk for ${projectId} hit the ${MAX_CHAIN_LENGTH} step limit`);
+    return { box: current, ended: false, steps };
+}
+
+/**
+ * The canonical box of a project, resolved from its mint rather than from its token id.
+ *
+ * Returns `box: null, ended: true` when the campaign has finished, and `box: null, ended: false`
+ * when the chain could not be resolved at all (no such token, or the explorer did not answer) -
+ * which the caller should treat as "unknown", not as "finished".
+ */
+export async function resolveCanonicalBox(projectId: string): Promise<LineageResult> {
+    const cached = lineageCache.get(projectId);
+    if (cached?.ended) return { box: null, ended: true, steps: 0 };
+    if (cached) return await walkForward(projectId, cached.box, 0);
+
+    const mintBoxId = await mintBoxOf(projectId);
+    if (!mintBoxId) return { box: null, ended: false, steps: 0 };
+
+    // The mint box is spent by creation Tx B, whose OUTPUTS(0) is the project box. mint_idt.es
+    // requires exactly that, so a project that exists at all starts here.
+    const mintBox = await boxById(mintBoxId);
+    if (!mintBox?.spentTransactionId) return { box: null, ended: false, steps: 0 };
+
+    const creationTx = await transactionById(mintBox.spentTransactionId);
+    const genesis = creationTx?.outputs?.[0];
+    if (!carriesProject(genesis, projectId)) return { box: null, ended: false, steps: 1 };
+
+    return await walkForward(projectId, genesis, 1);
+}
+
+/**
+ * Whether `boxId` is the canonical box of `projectId`.
+ *
+ * This is the question the UI actually needs answered when more than one box claims an id.
+ */
+export async function isCanonicalBox(projectId: string, boxId: string): Promise<boolean> {
+    const { box } = await resolveCanonicalBox(projectId);
+    return box?.boxId === boxId;
+}

--- a/src/routes/ProjectCard.svelte
+++ b/src/routes/ProjectCard.svelte
@@ -3,6 +3,7 @@
     import { is_ended, min_raised, type Project } from "$lib/common/project";
     import { project_detail, connected, balance } from "$lib/common/store";
     import { badgeVariants } from "$lib/components/ui/badge";
+    import LegacyContractBadge from "$lib/components/LegacyContractBadge.svelte";
     import { Button } from "$lib/components/ui/button";
     import * as Card from "$lib/components/ui/card";
     import { ErgoPlatform } from "$lib/ergo/platform";
@@ -120,6 +121,7 @@
             >
                 {project.content.title}
             </Card.Title>
+            <LegacyContractBadge {project} compact />
             <div hidden>
                 <a
                     href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"

--- a/src/routes/ProjectDetails.svelte
+++ b/src/routes/ProjectDetails.svelte
@@ -21,6 +21,7 @@
     import { formatTransactionError } from "$lib/common/error-utils";
     import { ErgoPlatform } from "$lib/ergo/platform";
     import ShareModal from "$lib/components/ShareModal.svelte";
+    import LegacyContractBadge from "$lib/components/LegacyContractBadge.svelte";
     import {
         web_explorer_uri_tkn,
         web_explorer_uri_tx,
@@ -724,6 +725,9 @@
             if (updatedProject) {
                 project = {
                     ...project,
+                    // The box is replaced below, so the version has to come with it: leaving the
+                    // old one would let the badge describe a box it is not looking at.
+                    version: updatedProject.version,
                     sold_counter: updatedProject.sold_counter,
                     current_value: updatedProject.current_value,
                     refund_counter: updatedProject.refund_counter,
@@ -759,6 +763,9 @@
         >
             <div class="project-header">
                 <h1 class="project-title">{project.content.title}</h1>
+                <div class="project-badge">
+                    <LegacyContractBadge {project} />
+                </div>
                 <div class="project-badge" style="display: none;">
                     <a
                         href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"

--- a/tests/frontend/fake_explorer.ts
+++ b/tests/frontend/fake_explorer.ts
@@ -1,0 +1,185 @@
+import { vi } from "vitest";
+import { get_dev_contract_hash, get_dev_fee } from "$lib/ergo/dev/dev_contract";
+
+/**
+ * A tiny in-memory stand-in for the Ergo explorer, serving only the three endpoints the lineage
+ * walk uses: `/api/v1/tokens/{id}`, `/api/v1/boxes/{boxId}` and `/api/v1/transactions/{txId}`.
+ *
+ * It records every path it is asked for, which is how the tests check that the cache actually
+ * saves work rather than merely returning the right answer twice.
+ */
+
+export const EXPLORER_URI = "https://explorer.test";
+
+export interface FakeBox {
+    boxId: string;
+    transactionId: string;
+    ergoTree: string;
+    value: number;
+    creationHeight: number;
+    assets: { tokenId: string; amount: number }[];
+    additionalRegisters: Record<string, any>;
+    spentTransactionId?: string | null;
+}
+
+export class FakeExplorer {
+    /** tokenId -> id of the box the token was minted in. */
+    tokens = new Map<string, string>();
+    boxes = new Map<string, FakeBox>();
+    txs = new Map<string, { id: string; outputs: FakeBox[] }>();
+    /** Every path requested, in order. */
+    calls: string[] = [];
+    /** Paths that should answer with a network-level failure rather than 404. */
+    unreachable = new Set<string>();
+    /**
+     * Boxes the unspent-by-token index does not list even though they are unspent - what a lagging
+     * or partial explorer index looks like from outside.
+     */
+    hiddenFromUnspent = new Set<string>();
+    /**
+     * Order of the unspent listing. Real explorers make no promise here, so tests that depend on
+     * picking the right box out of several should hold under both.
+     */
+    reverseUnspent = false;
+
+    private txCounter = 0;
+    private boxCounter = 0;
+
+    /** A box holding `tokenId` at index 0 - the shape the walk accepts as the project. */
+    box(tokenId: string | null, amount = 1, label?: string): FakeBox {
+        const boxId = label ?? `box${++this.boxCounter}`.padStart(64, "0");
+        const box: FakeBox = {
+            boxId,
+            transactionId: "",
+            ergoTree: "0008cd0000",
+            value: 1_000_000,
+            creationHeight: 800_000,
+            assets: tokenId === null ? [] : [{ tokenId, amount }],
+            additionalRegisters: {},
+            spentTransactionId: null,
+        };
+        this.boxes.set(boxId, box);
+        return box;
+    }
+
+    /** Register `box` as the box `tokenId` was minted in. */
+    mintedIn(tokenId: string, box: FakeBox) {
+        this.tokens.set(tokenId, box.boxId);
+    }
+
+    /** Spend `box` in a new transaction with the given outputs, in order. */
+    spend(box: FakeBox, outputs: FakeBox[]): string {
+        const txId = `tx${++this.txCounter}`;
+        const stored = this.boxes.get(box.boxId);
+        if (!stored) throw new Error(`spend() called on an unknown box ${box.boxId}`);
+        stored.spentTransactionId = txId;
+        for (const out of outputs) {
+            out.transactionId = txId;
+            this.boxes.set(out.boxId, out);
+        }
+        this.txs.set(txId, { id: txId, outputs });
+        return txId;
+    }
+
+    /** Install this explorer as `globalThis.fetch`. */
+    install() {
+        globalThis.fetch = vi.fn(async (url: any) => {
+            const full = String(url);
+            const path = full.startsWith(EXPLORER_URI) ? full.slice(EXPLORER_URI.length) : full;
+            this.calls.push(path);
+
+            if (this.unreachable.has(path)) throw new Error(`network error on ${path}`);
+
+            const body = this.route(path);
+            if (body === undefined) {
+                return { ok: false, status: 404, json: async () => ({}) } as any;
+            }
+            return { ok: true, status: 200, json: async () => body } as any;
+        }) as any;
+    }
+
+    /** How many times a path prefix was requested. */
+    countCalls(prefix: string): number {
+        return this.calls.filter((p) => p.startsWith(prefix)).length;
+    }
+
+    private route(path: string): any | undefined {
+        let match = path.match(/^\/api\/v1\/tokens\/(.+)$/);
+        if (match) {
+            const boxId = this.tokens.get(match[1]);
+            return boxId === undefined ? undefined : { id: match[1], boxId };
+        }
+
+        match = path.match(/^\/api\/v1\/boxes\/([^/]+)$/);
+        if (match) return this.boxes.get(match[1]);
+
+        match = path.match(/^\/api\/v1\/transactions\/(.+)$/);
+        if (match) return this.txs.get(match[1]);
+
+        match = path.match(/^\/api\/v1\/boxes\/unspent\/search\?(.*)$/);
+        if (match) {
+            const params = new URLSearchParams(match[1]);
+            const offset = Number(params.get("offset") ?? 0);
+            const limit = Number(params.get("limit") ?? 100);
+            // Everything that looks like a contract box: the scan matches on the ergo tree
+            // template, which these fixtures do not carry, so "has an R8" stands in for it.
+            const all = [...this.boxes.values()].filter(
+                (b) => !b.spentTransactionId && !this.hiddenFromUnspent.has(b.boxId) && b.additionalRegisters.R8
+            );
+            if (this.reverseUnspent) all.reverse();
+            return { items: all.slice(offset, offset + limit), total: all.length };
+        }
+
+        match = path.match(/^\/api\/v1\/boxes\/unspent\/byTokenId\/(.+?)(\?.*)?$/);
+        if (match) {
+            const items = [...this.boxes.values()].filter(
+                (b) =>
+                    !b.spentTransactionId &&
+                    !this.hiddenFromUnspent.has(b.boxId) &&
+                    b.assets.some((a) => a.tokenId === match![1])
+            );
+            if (this.reverseUnspent) items.reverse();
+            return { items, total: items.length };
+        }
+
+        return undefined;
+    }
+}
+
+export const PFT_TOKEN_ID = "d".repeat(64);
+
+/**
+ * Give a box the registers of a v2 project, so that `parseProjectBox` accepts it.
+ *
+ * Without this a fake box is rejected for having no registers, and a test meant to show that a
+ * box was *filtered out* would pass whether the filter ran or not.
+ */
+export function asV2Project(
+    box: FakeBox,
+    opts: { title?: string; pftTokenId?: string; pftAmount?: number; deadline?: number } = {}
+): FakeBox {
+    const pft = opts.pftTokenId ?? PFT_TOKEN_ID;
+    const owner = "0008cd03" + "11".repeat(32);
+    const content = JSON.stringify({
+        title: opts.title ?? "A project",
+        description: "",
+        link: null,
+        image: null,
+    });
+
+    box.assets = [box.assets[0], { tokenId: pft, amount: opts.pftAmount ?? 50_000 }];
+    box.additionalRegisters = {
+        R4: reg("(SBoolean, SLong)", `[false,${opts.deadline ?? 900_000}]`),
+        R5: reg("SLong", "1000"),
+        R6: reg("Coll[SLong]", "[0,0,0]"),
+        R7: reg("SLong", "1000000"),
+        // owner, dev contract hash, dev fee (hex), PFT id - and no base token, so ERG mode.
+        R8: reg("Coll[Coll[SByte]]", `[${owner},${get_dev_contract_hash()},${get_dev_fee().toString(16)},${pft}]`),
+        R9: reg("Coll[SByte]", Buffer.from(content, "utf-8").toString("hex")),
+    };
+    return box;
+}
+
+function reg(sigmaType: string, renderedValue: string) {
+    return { sigmaType, renderedValue, serializedValue: "00" };
+}

--- a/tests/frontend/legacy_version.test.ts
+++ b/tests/frontend/legacy_version.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { is_legacy_version, type Project } from "$lib/common/project";
+import { ErgoPlatform } from "$lib/ergo/platform";
+import type { contract_version } from "$lib/ergo/contract";
+
+/**
+ * The badge that marks a campaign as running on an older contract. The point of these tests is
+ * not the string on screen but the rule behind it: "older than what the platform deploys today",
+ * so that publishing a new contract marks the previous one on its own.
+ */
+
+function projectOn(version: string, deployed: string): Project {
+    return { version, platform: { last_version: deployed } } as unknown as Project;
+}
+
+describe("is_legacy_version", () => {
+    it("marks the versions older than the deployed one", () => {
+        expect(is_legacy_version(projectOn("v1_0", "v2"))).toBe(true);
+        expect(is_legacy_version(projectOn("v1_1", "v2"))).toBe(true);
+    });
+
+    it("leaves the deployed version unmarked", () => {
+        expect(is_legacy_version(projectOn("v2", "v2"))).toBe(false);
+    });
+
+    it("marks the previous version as soon as a new one is deployed", () => {
+        // Nobody has to come back and edit a list when v3 ships: v2 becomes legacy by itself, and
+        // v3 does not mark itself.
+        expect(is_legacy_version(projectOn("v2", "v3"))).toBe(true);
+        expect(is_legacy_version(projectOn("v3", "v3"))).toBe(false);
+    });
+
+    it("agrees with what the platform actually deploys right now", () => {
+        const deployed: contract_version = new ErgoPlatform().last_version;
+
+        expect(is_legacy_version(projectOn(deployed, deployed))).toBe(false);
+        expect(is_legacy_version(projectOn("v1_0", deployed))).toBe(true);
+    });
+});

--- a/tests/frontend/lineage.test.ts
+++ b/tests/frontend/lineage.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { explorer_uri } from "$lib/common/store";
+import {
+    resolveCanonicalBox,
+    isCanonicalBox,
+    clearLineageCache,
+} from "$lib/ergo/lineage";
+import { FakeExplorer, EXPLORER_URI, type FakeBox } from "./fake_explorer";
+
+/**
+ * The lineage walk is the answer to #176: a project has no verifiable identity in v1/v2, so the
+ * only thing that distinguishes the real box from an imitation is that it descends from the mint
+ * through OUTPUTS(0). These tests are about that distinction holding - and about the walk not
+ * inventing an answer when the chain cannot be read.
+ */
+
+const PROJECT_ID = "a".repeat(64);
+const OTHER_TOKEN = "b".repeat(64);
+
+let explorer: FakeExplorer;
+const realFetch = globalThis.fetch;
+
+/**
+ * A project with `actions` replications: mint -> genesis -> ... , the head left unspent.
+ * Returns the boxes in order, so a test can name the head or any ancestor.
+ */
+function campaign(actions: number): FakeBox[] {
+    const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+    explorer.mintedIn(PROJECT_ID, mintBox);
+
+    const genesis = explorer.box(PROJECT_ID, 100, "genesis");
+    explorer.spend(mintBox, [genesis]);
+
+    const chain = [genesis];
+    for (let i = 0; i < actions; i++) {
+        const next = explorer.box(PROJECT_ID, 100 - i - 1, `replica${i}`);
+        explorer.spend(chain[chain.length - 1], [next]);
+        chain.push(next);
+    }
+    return chain;
+}
+
+beforeEach(() => {
+    explorer = new FakeExplorer();
+    explorer.install();
+    explorer_uri.set(EXPLORER_URI);
+    clearLineageCache();
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+});
+
+describe("resolveCanonicalBox", () => {
+    it("reaches the head of the chain from the mint", async () => {
+        const chain = campaign(3);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box?.boxId).toBe(chain[chain.length - 1].boxId);
+        expect(result.ended).toBe(false);
+        expect(result.steps).toBe(4); // genesis + three replications
+    });
+
+    it("resolves a project that has never been spent since creation", async () => {
+        const chain = campaign(0);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box?.boxId).toBe(chain[0].boxId);
+        expect(result.ended).toBe(false);
+    });
+
+    it("reports the campaign as ended when the chain terminates", async () => {
+        const chain = campaign(2);
+        // A closing transaction pays the owner at OUTPUTS(0): no project token there.
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(true);
+    });
+
+    it("does not follow a box that carries a different token at index 0", async () => {
+        const chain = campaign(1);
+        // The project token is in the box, but not at index 0 - so by the contract's own `sameId`
+        // check this is not the project carried forward, whatever else it is.
+        const impostor = explorer.box(OTHER_TOKEN, 5, "impostor");
+        impostor.assets.push({ tokenId: PROJECT_ID, amount: 1 });
+        explorer.spend(chain[chain.length - 1], [impostor]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(true);
+    });
+
+    it("does not accept a creation output that is not at index 0", async () => {
+        // mint_idt.es requires the project at OUTPUTS(0), so a transaction that puts it elsewhere
+        // did not create a project this platform should recognise.
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        explorer.spend(mintBox, [explorer.box(OTHER_TOKEN, 1, "decoy"), explorer.box(PROJECT_ID, 100, "aside")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+});
+
+describe("what the walk refuses to conclude", () => {
+    it("treats an unknown token as unresolved, not as ended", async () => {
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("treats a never-spent mint box as unresolved", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("treats a creation transaction that does not produce the project as unresolved", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        explorer.spend(mintBox, [explorer.box(OTHER_TOKEN, 1, "notaproject")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("reports the last box it knows, not 'ended', when the explorer has no answer for it", async () => {
+        const chain = campaign(1);
+        const head = chain[chain.length - 1];
+        explorer.boxes.delete(head.boxId); // the explorer 404s on a box it has just told us about
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        // Saying "ended" here would hide a live campaign on a transient explorer gap.
+        expect(result.ended).toBe(false);
+        expect(result.box?.boxId).toBe(head.boxId);
+    });
+
+    it("propagates a network failure rather than answering from nothing", async () => {
+        const chain = campaign(1);
+        explorer.unreachable.add(`/api/v1/boxes/${chain[chain.length - 1].boxId}`);
+
+        await expect(resolveCanonicalBox(PROJECT_ID)).rejects.toThrow();
+    });
+
+    it("stops instead of spinning when the chain loops back on itself", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        const a = explorer.box(PROJECT_ID, 100, "loopa");
+        const b = explorer.box(PROJECT_ID, 100, "loopb");
+        explorer.spend(mintBox, [a]);
+        explorer.spend(a, [b]);
+        explorer.spend(b, [a]); // a is now spent by two transactions: only a fixture can do this
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.ended).toBe(false);
+        expect(result.steps).toBe(5000); // MAX_CHAIN_LENGTH
+    }, 30_000);
+});
+
+describe("isCanonicalBox", () => {
+    it("accepts the box the lineage reaches", async () => {
+        const chain = campaign(2);
+
+        expect(await isCanonicalBox(PROJECT_ID, chain[chain.length - 1].boxId)).toBe(true);
+    });
+
+    it("rejects an imitation that holds the project token but is not on the path", async () => {
+        campaign(2);
+        // Anyone holding one unit of the APT can build this: same token at index 0, unspent,
+        // and as far as `boxes/unspent/byTokenId` is concerned indistinguishable from the real one.
+        const imitation = explorer.box(PROJECT_ID, 1, "imitation");
+
+        expect(await isCanonicalBox(PROJECT_ID, imitation.boxId)).toBe(false);
+    });
+
+    it("rejects a clone slipped into the closing transaction at an index other than 0", async () => {
+        // This is #174: the transaction that ends the campaign also creates a copy, which the old
+        // by-token lookup then presented as the live project.
+        const chain = campaign(1);
+        const payout = explorer.box(null, 0, "payout");
+        const clone = explorer.box(PROJECT_ID, 1, "clone");
+        explorer.spend(chain[chain.length - 1], [payout, explorer.box(null, 0, "change"), clone]);
+
+        expect(await isCanonicalBox(PROJECT_ID, clone.boxId)).toBe(false);
+        expect((await resolveCanonicalBox(PROJECT_ID)).ended).toBe(true);
+    });
+
+    it("rejects an ancestor: the project is where the chain is now, not where it was", async () => {
+        const chain = campaign(3);
+
+        expect(await isCanonicalBox(PROJECT_ID, chain[0].boxId)).toBe(false);
+    });
+});
+
+describe("the cache", () => {
+    it("continues from where it stopped instead of walking from the mint again", async () => {
+        const chain = campaign(3);
+        await resolveCanonicalBox(PROJECT_ID);
+        const afterFirst = explorer.calls.length;
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.box?.boxId).toBe(chain[chain.length - 1].boxId);
+        expect(second.steps).toBe(0);
+        expect(explorer.calls.length).toBeLessThan(afterFirst);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(0);
+    });
+
+    it("picks up the actions taken since the last walk", async () => {
+        const chain = campaign(1);
+        await resolveCanonicalBox(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const later = explorer.box(PROJECT_ID, 50, "later");
+        explorer.spend(chain[chain.length - 1], [later]);
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.box?.boxId).toBe(later.boxId);
+        expect(second.steps).toBe(1);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(0);
+    });
+
+    it("answers an ended campaign without asking the explorer again", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        await resolveCanonicalBox(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.ended).toBe(true);
+        expect(explorer.calls.length).toBe(0);
+    });
+
+    it("walks again from the mint once cleared", async () => {
+        campaign(2);
+        await resolveCanonicalBox(PROJECT_ID);
+        clearLineageCache(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.steps).toBe(3);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(1);
+    });
+});

--- a/tests/frontend/project_lookup.test.ts
+++ b/tests/frontend/project_lookup.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { get } from "svelte/store";
+import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
+import { clearLineageCache } from "$lib/ergo/lineage";
+import { fetchProjectById, fetchProjectsFromBlockchain } from "$lib/ergo/fetch";
+import { FakeExplorer, EXPLORER_URI, asV2Project, type FakeBox } from "./fake_explorer";
+
+/**
+ * #178 made the UI refuse to display a campaign when two unspent boxes claim its id, because
+ * nothing in the boxes says which is real. The lineage walk is what can say: the campaign is the
+ * box that descends from the mint through OUTPUTS(0). These tests are about the two halves fitting
+ * together - a collision the chain can settle is displayed, one it cannot is still refused - and
+ * about never falling back to "whichever box the explorer listed first".
+ *
+ * Every box a test expects to be rejected is built as a valid v2 project, so that rejecting it has
+ * to be the lineage's doing and not a parse failure.
+ */
+
+const PROJECT_ID = "c".repeat(64);
+
+let explorer: FakeExplorer;
+const realFetch = globalThis.fetch;
+
+function campaign(actions: number): FakeBox[] {
+    const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+    explorer.mintedIn(PROJECT_ID, mintBox);
+    const genesis = asV2Project(explorer.box(PROJECT_ID, 100, "genesis"), { title: "The real one" });
+    explorer.spend(mintBox, [genesis]);
+
+    const chain = [genesis];
+    for (let i = 0; i < actions; i++) {
+        const next = asV2Project(explorer.box(PROJECT_ID, 100 - i - 1, `replica${i}`), {
+            title: "The real one",
+        });
+        explorer.spend(chain[chain.length - 1], [next]);
+        chain.push(next);
+    }
+    return chain;
+}
+
+/** The #176 box: same script, same token, registers of its author's choosing, never on the path. */
+function imitation(label: string): FakeBox {
+    return asV2Project(explorer.box(PROJECT_ID, 1, label), { title: "The fake one" });
+}
+
+beforeEach(() => {
+    explorer = new FakeExplorer();
+    explorer.install();
+    explorer_uri.set(EXPLORER_URI);
+    clearLineageCache();
+    projects.set({ data: new Map(), last_fetch: 0 });
+    project_id_conflicts.set(new Map());
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+});
+
+describe("the campaign page", () => {
+    // A real explorer promises nothing about the order of the unspent listing, and "whichever came
+    // first" is exactly the rule this replaces, so both orders are checked.
+    it.each([false, true])(
+        "shows the box the lineage reached, not the imitation beside it (reversed: %s)",
+        async (reversed) => {
+            explorer.reverseUnspent = reversed;
+            const chain = campaign(2);
+            imitation("imitation");
+
+            const project = await fetchProjectById(PROJECT_ID);
+
+            expect(project?.box.boxId).toBe(chain[chain.length - 1].boxId);
+            expect(project?.content.title).toBe("The real one");
+            // A collision the chain can settle is not a conflict any more.
+            expect(get(project_id_conflicts).has(PROJECT_ID)).toBe(false);
+        }
+    );
+
+    it("shows an ordinary campaign with nothing competing for its id", async () => {
+        const chain = campaign(1);
+
+        const project = await fetchProjectById(PROJECT_ID);
+
+        expect(project?.box.boxId).toBe(chain[chain.length - 1].boxId);
+    });
+
+    it("shows nothing for a campaign whose chain has ended", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        // A clone left unspent by the closing transaction - the #174 shape. It is the only box
+        // carrying the token now, so before this it was the campaign page.
+        imitation("clone");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+        expect(explorer.countCalls("/api/v1/boxes/unspent/")).toBe(0);
+    });
+
+    it("shows nothing when the box the lineage reached is not among the unspent ones", async () => {
+        const chain = campaign(1);
+        // The unspent index does not list the real box - a lagging index, say. The imitation is
+        // listed, and falling back to it is the one thing that must not happen.
+        explorer.hiddenFromUnspent.add(chain[chain.length - 1].boxId);
+        imitation("imitation");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+    });
+
+    it("still refuses a tie the lineage cannot settle", async () => {
+        // No mint registered: the walk cannot start, so nothing establishes which is which and the
+        // behaviour #178 introduced has to stand.
+        imitation("one");
+        imitation("two");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+
+    it("still shows a lone box when the lineage cannot be resolved", async () => {
+        // The explorer being unable to answer should not take every campaign off the site; with a
+        // single candidate there is nothing to be misled between, so this stays as it was.
+        asV2Project(explorer.box(PROJECT_ID, 100, "only"), { title: "Alone" });
+
+        expect((await fetchProjectById(PROJECT_ID))?.box.boxId).toBe("only");
+    });
+});
+
+describe("the campaign list", () => {
+    it.each([false, true])(
+        "lists the box the lineage reached when two claim one id (reversed: %s)",
+        async (reversed) => {
+            explorer.reverseUnspent = reversed;
+            const chain = campaign(1);
+            imitation("imitation");
+
+            await fetchProjectsFromBlockchain();
+
+            const listed = get(projects).data.get(PROJECT_ID);
+            expect(listed?.box.boxId).toBe(chain[chain.length - 1].boxId);
+            expect(listed?.content.title).toBe("The real one");
+            expect(get(project_id_conflicts).has(PROJECT_ID)).toBe(false);
+        }
+    );
+
+    it("lists a campaign untouched when nothing else claims its id", async () => {
+        const chain = campaign(1);
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.get(PROJECT_ID)?.box.boxId).toBe(chain[chain.length - 1].boxId);
+        // Nothing collided, so the walk should not have been paid for at all: one call per
+        // campaign per sweep is not a cost the listing can carry.
+        expect(explorer.countCalls("/api/v1/tokens/" + PROJECT_ID)).toBe(0);
+    });
+
+    it("hides the leftovers of a campaign that has ended", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        imitation("clone");
+        imitation("another");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["clone", "another"]);
+    });
+
+    it("hides a collision when the real box is neither of the two", async () => {
+        // The campaign is live and its box is simply not in the unspent listing this sweep, while
+        // two imitations are. Neither is the campaign, and neither may be shown as one.
+        const chain = campaign(1);
+        explorer.hiddenFromUnspent.add(chain[chain.length - 1].boxId);
+        imitation("one");
+        imitation("two");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+
+    it("still hides a campaign whose collision the lineage cannot settle", async () => {
+        imitation("one");
+        imitation("two");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+});

--- a/tests/stubs/wallet-svelte-component.ts
+++ b/tests/stubs/wallet-svelte-component.ts
@@ -1,0 +1,35 @@
+// Stub for wallet-svelte-component.
+//
+// The published package ships Svelte components and extensionless ESM imports that Node cannot
+// resolve, so vitest dies during collection with ERR_MODULE_NOT_FOUND before running a single
+// test - including the tests already in the repo. It is pulled in transitively by $lib, so
+// aliasing it to this module in vitest.config.ts is what lets the suite run at all.
+//
+// The surface here is deliberately the smallest thing that keeps module initialisation working:
+// stores that can be subscribed to and written, and wallet calls that refuse loudly. Nothing
+// under tests/ signs or submits anything, so a test that reaches one of these has gone wrong and
+// should say so rather than quietly do nothing.
+import { writable } from "svelte/store";
+
+export const explorerUri = writable<string>("https://api.ergoplatform.com");
+export const walletConnected = writable<boolean>(false);
+export const walletAddress = writable<string>("");
+
+const notInTests = (name: string) => async () => {
+    throw new Error(`${name}() is not available in tests: the wallet is stubbed out`);
+};
+
+export const walletManager = {
+    connectWallet: notInTests("walletManager.connectWallet"),
+    disconnect: notInTests("walletManager.disconnect"),
+};
+
+export const getCurrentHeight = notInTests("getCurrentHeight");
+export const getChangeAddress = notInTests("getChangeAddress");
+export const signTransaction = notInTests("signTransaction");
+export const submitTransaction = notInTests("submitTransaction");
+export const getUtxos = notInTests("getUtxos");
+
+export const WalletAddressChangeHandler = {};
+
+export default {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   resolve: {
     alias: {
       $lib: path.resolve(__dirname, './src/lib'),
+      // wallet-svelte-component ships .svelte files and extensionless ESM imports that Node
+      // cannot resolve, so vitest dies during collection - before running a single test,
+      // including the ones already in the repo. It is pulled in transitively by $lib and no
+      // test touches it, so it is stubbed out here.
+      'wallet-svelte-component': path.resolve(__dirname, './tests/stubs/wallet-svelte-component.ts'),
     },
   },
 });


### PR DESCRIPTION
The first two frontend items of #176, on top of #178.

#178 detects that two unspent boxes claim one project id and hides the campaign, because nothing **in** the boxes says which is real, and it says the real fix is canonical-box resolution by lineage. This is that.

## The walk

A project is `OUTPUTS(0)` of the transaction that spends its mint box, and stays `OUTPUTS(0)` of every transaction that spends it afterwards, because the contract requires the replica at index 0. So walking that chain from the mint reaches exactly one box, and an imitation - created by some unrelated transaction, or at an index other than 0 - is never on it. `src/lib/ergo/lineage.ts` does the walk; it is cached and incremental, so a campaign already resolved is only walked forward from where it was left, not from the mint again.

It also gets termination right for free: when a campaign closes, `OUTPUTS(0)` of the closing transaction is a payment box rather than a replica, so the chain ends and the campaign is reported as finished. That covers the #174 shape, where a clone was slipped into the closing transaction at index 2 and then presented as the live campaign.

## What changes for a visitor

| situation | before | after |
|---|---|---|
| two boxes claim one id, chain resolves | campaign hidden | the box the chain reaches is shown |
| two boxes claim one id, chain does not resolve | campaign hidden | unchanged - hidden, recorded in `project_id_conflicts` |
| campaign ended, a clone left behind | clone shown as the campaign | nothing shown |
| ordinary campaign, nothing competing | shown | shown |

The listing only walks when there is an actual collision - one explorer call per campaign per sweep is not a cost it can carry. The campaign page always walks, because that is the page someone reads before sending money, and the cache makes a second visit one call.

## The badge

`is_legacy_version` compares against the version the platform deploys today rather than a list of old versions, so publishing a new contract marks its predecessor without anyone having to remember to come back here. Both `ProjectCard` and `ProjectDetails` already carried a hidden block with the contract version; this is the same information made visible, and only when it is worth acting on.

The screenshot below was taken with `last_version` temporarily set to `v1_0`, because every campaign live today is on v2 and the badge would otherwise be invisible. As things stand it lights up for v1_0 and v1_1 only, and v2 lights up by itself the day v3 ships.

## Tests

36 tests in `tests/frontend/`, against an in-memory explorer: the walk, what it refuses to conclude, the cache, both call sites in `fetch.ts`, and the rule behind the badge.

Every box a test expects to be *rejected* is built as a valid v2 project, so that rejecting it has to be the lineage's doing and not a parse failure. That was not true of my first draft, which passed for the wrong reason.

I then mutated the code under test 15 ways - drop the index-0 requirement, accept the token anywhere in the box, settle a collision by taking the newer box, treat an unreadable box as the end of the chain, remove the step limit, fall back to a candidate the walk did not name, and so on. All 15 are caught. Two earlier mutants survived as equivalent mutants, which is why `resolveByLineage` has no `if (!box)` branch: it was dead weight that made the tests look weaker than they are.

`npm test` on this branch: **8 failed | 151 passed**. The 8 are the ones already on main - the 7 listed in #180, plus `replication_guard.test.ts` from #174, which is red on purpose. None of them touch this change.

## Not in this PR

The v3 singleton NFT (#179). Once a campaign carries an NFT the walk is no longer needed for it, but it is needed for every v1 and v2 campaign already on chain, and those will not be migrated.

An ended campaign reaches `loadProjectById` as "not found" rather than "this campaign has finished". Worth a message of its own; I left `project_load_error` alone rather than widening the change.

## Note

`vitest.config.ts` and `tests/stubs/wallet-svelte-component.ts` overlap #180 - without them vitest cannot collect and none of this runs. The stub here has a slightly larger surface, because `ErgoPlatform`'s constructor subscribes to the library's `explorerUri` store. Whichever of the two lands first, the other becomes a no-op.

<img width="1260" height="620" alt="legacy-badge-cards" src="https://github.com/user-attachments/assets/a74e243d-f39a-4f01-be28-231ba0be68f1" />


*The badge on the campaign cards, with `last_version` temporarily set to `v1_0` so that the v2 campaigns live today show it. Same chip in a longer form on the campaign page.*