### PR TITLE
Frontend support for v3: NFT identity and a version-aware dev fee (#176, #177)

### DIFF
--- a/contracts/bene_contract/contract_v3.es
+++ b/contracts/bene_contract/contract_v3.es
@@ -1,0 +1,651 @@
+{
+
+// ===== Contract Description ===== //
+// Name: Bene Fundraising Platform Contract (Multi-Token Support)
+// Description: Enables a project to receive funding in exchange for participation tokens using any base token.
+// Version: 1.3.0
+// Author: The Stable Order
+
+// ===== CHANGES FROM v1.2.1 (contract_v2.es) ===== //
+// This file addresses #78 / #174 (replication guard), #176 (project identity) and #177 (dev fee
+// evasion). contract_v2.es is deliberately left untouched: the frontend compiles that source at
+// runtime to derive the template hash it searches boxes with and the ErgoTree it rebuilds replicas
+// with, so changing it would drop every live v2 project out of the platform and invalidate their
+// transactions against sameScript.
+//
+// 1. Project identity is a singleton NFT at tokens(0) with amount 1 (#176). In v2 the identity was
+//    tokens(0) = the APT, whose amount is the PFT emission + 1 and which circulates to buyers by
+//    design, so several boxes could carry it at once and none of them was distinguishable.
+//
+// 2. Replication is structural (#174). v2 decided it was being replicated by looking at OUTPUTS(0)
+//    alone, and wrote every guard as !isReplicationBoxPresent || (...), so a copy at any other
+//    index left all of them vacuously true. Here a box carrying this script may appear at most
+//    once among the outputs, and when it appears it must be at OUTPUTS(0) - checked once, at the
+//    top level, for every action. A clone can no longer be slipped into isBuyTokens, isAddTokens,
+//    isExchangeFundingTokens or isWithdrawFunds either.
+//
+// 3. The NFT is either in the replica or in an unspendable terminal box, never anywhere else and
+//    never in two places (#176). This is what makes a closed campaign impossible to resurrect.
+//
+// 4. Termination is only possible through isWithdrawFunds (#177), which forces the owner + dev fee
+//    split. isWithdrawUnsoldTokens always replicates again, as it did before v1.2.1: allowing it
+//    to terminate left mantainValue vacuous, so the owner could take the whole balance without
+//    paying the fee. The reason it was allowed to terminate - sparing the frontend from leaving
+//    1 smallest unit of PFT behind so the box stayed identifiable - is gone with the NFT.
+//
+// 5. The dev fee is rounded up and must be strictly positive whenever anything is extracted (#177),
+//    so it can no longer be truncated away by withdrawing 19 units at a time on a token campaign.
+//
+// 6. minnerFeeAmount, declared and never used in v2, is gone. Its comment claimed it let the
+//    withdrawal pay the miner fee out of the extracted value, but the contract requires the owner
+//    to receive exactly extracted - devFee, so there was never anything left for it.
+
+// ===== Box Contents ===== //
+// Tokens
+// 0. (id, amount)
+//    Project NFT; identifies the project. Minted with the project box in creation Tx B.
+//    where:
+//       id      The project identifier. On Ergo the minted id is INPUTS(0).boxId, and input 0 of
+//               Tx B is the mint box, so the id is deterministic and known once Tx A confirms.
+//       amount  Always 1.
+// 1. (id, amount)
+//    APT; temporary funding token, handed to contributors and exchanged back for PFT.
+//    where:
+//       id      The APT (IDT) identifier.
+//       amount  PFT emission amount + 1
+//               The +1 is kept so that the APT is always present, which is what lets every action
+//               address it at a fixed index. It no longer carries identity - the NFT does.
+// 2. (id, amount)
+//    PFT; Proof of funding token
+//    where:
+//       id      The project token identifier.
+//       amount  The number of tokens equivalent to the maximum amount of base token the project aims to raise.
+// 3. (id, amount)
+//    Base token, only when the campaign is not denominated in ERG.
+
+// Registers
+// R4: (Boolean, Long)       This tuple specifies the temporal limit for refund prohibition. The Boolean indicates the limit type (false for Block Height, true for Timestamp), and the Long holds the limit value. Refunds are only allowed after this point if the minimum threshold was not met.
+// R5: Long                  The minimum number of tokens that must be sold to trigger certain actions (e.g., withdrawals).
+// R6: Coll[Long]            The total number of tokens sold, the total number of tokens refunded and the total number of APT changed per PFT so far.
+// R7: Long                  Base token exchange rate (base token per PFT)
+// R8: Coll[Coll[Byte]]      Constants [owner_ergotree, dev_fee_contract_bytes_hash, dev_fee, pft_token_id, base_token_id] as Base58-encoded JSON strings.
+// R9: Coll[Byte]            Base58-encoded JSON string containing project metadata, including "title" and "description".
+
+// ===== R8 Constants ===== //
+// $owner_ergotree: ErgoTree bytes (hex) of the contract owner (supports both P2PK and P2S).
+// $dev_fee_contract_bytes_hash: Blake2b-256 base16 string hash of the dev fee contract proposition bytes.
+// $dev_fee: Percentage fee allocated to the developer (e.g., 5 for 5%).
+// $pft_token_id: Unique string identifier for the proof-of-funding token.
+// $base_token_id: Base token ID for contributions (empty string for ERG).
+
+  val r8 = SELF.R8[Coll[Coll[Byte]]].get
+
+  val ownerErgoTree           = r8(0)
+  val devFeeContractBytesHash = r8(1)
+  val devFee                  = byteArrayToBigInt(r8(2))
+  val pftTokenId              = r8(3)
+  val baseTokenId             = if (r8.size > 4) r8(4) else Coll[Byte]()
+
+  val selfId = SELF.tokens(0)._1          // Project NFT. Identity, amount 1.
+  val selfAPTId = SELF.tokens(1)._1
+  val selfAPT = SELF.tokens(1)._2
+  val selfValue = SELF.value
+  val selfBlockLimit = SELF.R4[(Boolean, Long)].get
+  val selfMinimumTokensSold = SELF.R5[Long].get
+  val selfSoldCounter = SELF.R6[Coll[Long]].get(0)
+  val selfRefundCounter = SELF.R6[Coll[Long]].get(1)
+  val selfAuxiliarExchangeCounter = SELF.R6[Coll[Long]].get(2)
+  val selfExchangeRate = SELF.R7[Long].get
+  val selfConstants = SELF.R8[Coll[Coll[Byte]]].get
+  val selfProjectMetadata = SELF.R9[Coll[Byte]].get
+  val selfScript = SELF.propositionBytes
+
+  // Proposition bytes of { sigmaProp(false) }. The project NFT is sent to a box with this script
+  // when the campaign ends: nothing can ever spend it, so the identity cannot come back.
+  val terminalScript = fromBase16("1906010100d17300")
+
+  // ===== Replication, structurally ===== //
+  // v2 asked only whether OUTPUTS(0) carried this script, which said nothing about copies sitting
+  // at other indices. Here we count them.
+  val replicas = OUTPUTS.filter({(box: Box) => box.propositionBytes == selfScript})
+
+  // At most one box carrying this script may leave the transaction. Enforced at the top level, so
+  // it holds for every action rather than for the ones that remembered to ask.
+  val noExtraReplicas = replicas.size <= 1
+
+  val isReplicationBoxPresent = replicas.size == 1 && OUTPUTS(0).propositionBytes == selfScript
+
+  // Get base token information
+  val isERGBase = baseTokenId.size == 0
+
+  // HELP FUNCTIONS
+
+  def temporaryFundingTokenAmountOnContract(contract: Box): Long = {
+    // APT amount that serves as temporary funding token that is currently on the contract available to exchange.
+
+    val pfts = contract.tokens.filter { (token: (Coll[Byte], Long)) =>
+      token._1 == pftTokenId
+    }
+    val proof_funding_token_amount = if (pfts.size > 0) { pfts(0)._2 } else { 0L }
+    val sold                       = contract.R6[Coll[Long]].get(0)
+    val refunded                   = contract.R6[Coll[Long]].get(1)
+    val exchanged                  = contract.R6[Coll[Long]].get(2)  // If the exchanged APT -> PFT amount is not accounted for, it will result in double-counting the sold amount.
+
+    val calculation = proof_funding_token_amount - sold + refunded + exchanged
+    if (calculation < 0L) 0L else calculation
+  }
+
+  def getBaseTokenAmount(box: Box): Long = {
+    if (isERGBase) {
+      box.value
+    } else {
+      val matchingTokens = box.tokens.filter { (token: (Coll[Byte], Long)) =>
+        token._1 == baseTokenId
+      }
+      if (matchingTokens.size > 0) {
+        matchingTokens(0)._2
+      } else {
+        0L
+      }
+    }
+  }
+
+  // ===== The project NFT never escapes ===== //
+  // Exactly one output carries it, at its index 0 and with amount 1, and that output is either the
+  // replica or the terminal box. Checked at the top level, so no action can drop it, split it,
+  // burn it or hand it to a box of the spender's choosing.
+  val nftHolders = OUTPUTS.filter({(box: Box) =>
+    box.tokens.exists({(token: (Coll[Byte], Long)) => token._1 == selfId})
+  })
+
+  val nftWellPlaced = nftHolders.size == 1 &&
+    nftHolders(0).tokens(0)._1 == selfId &&
+    nftHolders(0).tokens(0)._2 == 1L
+
+  val nftInReplica = isReplicationBoxPresent && nftWellPlaced &&
+    OUTPUTS(0).tokens(0)._1 == selfId
+
+  val nftRetired = nftWellPlaced && nftHolders(0).propositionBytes == terminalScript
+
+  // Validation of the box replication process
+  val isSelfReplication = {
+    isReplicationBoxPresent && {
+      // The project NFT must be the same, at index 0, and still a singleton
+      val sameId = selfId == OUTPUTS(0).tokens(0)._1 && OUTPUTS(0).tokens(0)._2 == 1L
+
+      // The APT must stay at index 1, so that every action can address it there
+      val sameAPTId = selfAPTId == OUTPUTS(0).tokens(1)._1
+
+      // The block limit must be the same
+      val sameBlockLimit = selfBlockLimit == OUTPUTS(0).R4[(Boolean, Long)].get
+
+      // The minimum amount of tokens sold must be the same
+      val sameMinimumSold = selfMinimumTokensSold == OUTPUTS(0).R5[Long].get
+
+      // The exchange rate and base token info must be same
+      val sameExchangeRate = selfExchangeRate == OUTPUTS(0).R7[Long].get
+
+      // The constants must be the same
+      val sameConstants = selfConstants == OUTPUTS(0).R8[Coll[Coll[Byte]]].get
+
+      // The project content must be the same
+      val sameProjectContent = selfProjectMetadata == OUTPUTS(0).R9[Coll[Byte]].get
+
+      // The script must be the same
+      val sameScript = selfScript == OUTPUTS(0).propositionBytes
+
+      // NFT and APT are always there; PFT and, on a token campaign, the base token may or may not be.
+      val noAddsOtherTokens = if (isERGBase) {
+        OUTPUTS(0).tokens.size == 2 || OUTPUTS(0).tokens.size == 3
+      } else {
+        OUTPUTS(0).tokens.size == 2 || OUTPUTS(0).tokens.size == 3 || OUTPUTS(0).tokens.size == 4
+      }
+
+      // Verify that the output box is a valid copy of the input box
+      sameId && sameAPTId && sameBlockLimit && sameMinimumSold && sameExchangeRate && sameConstants && sameProjectContent && sameScript && noAddsOtherTokens
+    }
+  }
+
+  val APTokenRemainsConstant = !isReplicationBoxPresent || (selfAPT == OUTPUTS(0).tokens(1)._2)
+  val ProofFundingTokenRemainsConstant = {
+    !isReplicationBoxPresent || {
+      val selfAmount = {
+        val pfts = SELF.tokens.filter { (token: (Coll[Byte], Long)) =>
+          token._1 == pftTokenId
+        }
+        if (pfts.size > 0) { pfts(0)._2 } else { 0L }
+      }
+
+      val outAmount = {
+        val pfts = OUTPUTS(0).tokens.filter { (token: (Coll[Byte], Long)) =>
+          token._1 == pftTokenId
+        }
+        if (pfts.size > 0) { pfts(0)._2 } else { 0L }
+      }
+
+      selfAmount == outAmount
+    }
+  }
+  val soldCounterRemainsConstant = !isReplicationBoxPresent || (selfSoldCounter == OUTPUTS(0).R6[Coll[Long]].get(0))
+  val refundCounterRemainsConstant = !isReplicationBoxPresent || (selfRefundCounter == OUTPUTS(0).R6[Coll[Long]].get(1))
+  val auxiliarExchangeCounterRemainsConstant = !isReplicationBoxPresent || (selfAuxiliarExchangeCounter == OUTPUTS(0).R6[Coll[Long]].get(2))
+  val mantainValue = !isReplicationBoxPresent || ({
+    selfValue == OUTPUTS(0).value &&
+    {
+      if (isERGBase) { true }
+      else {
+        val selfBaseAmount = getBaseTokenAmount(SELF)
+        val outBaseAmount = getBaseTokenAmount(OUTPUTS(0))
+        selfBaseAmount == outBaseAmount
+      }
+    }
+  })
+
+  // Project owner address as ErgoTree bytes (can be P2PK or P2S)
+  val P2PK_ERGOTREE_PREFIX = fromBase16("0008cd")
+
+  // Check if project address is P2PK or P2S by examining the prefix
+  val isProjectP2PK: Boolean = if (ownerErgoTree.size >= 3) {
+    ownerErgoTree.slice(0, 3) == P2PK_ERGOTREE_PREFIX
+  } else {
+    false
+  }
+
+  // Create SigmaProp for project address
+
+  val ownerAuthentication: SigmaProp = {
+
+    val projectAddr: SigmaProp = if (isProjectP2PK) {
+      // For P2PK: Extract the public key and create SigmaProp with proveDlog
+      val pkContent = ownerErgoTree.slice(3, ownerErgoTree.size)
+      proveDlog(decodePoint(pkContent))
+    } else {
+      // For P2S: We check proposition bytes directly on INPUTS
+      sigmaProp(false)
+    }
+
+    val signedByInput: SigmaProp = sigmaProp(INPUTS.exists({(box: Box) => box.propositionBytes == ownerErgoTree}))
+
+    signedByInput || projectAddr
+  }
+
+  // Amount of PFT tokens added to the contract. In case of negative value, means that the token have been extracted.
+  val deltaPFTokenAdded: Long = {
+    val selfTokens = {
+      val pfts = SELF.tokens.filter { (token: (Coll[Byte], Long)) =>
+        token._1 == pftTokenId
+      }
+      if (pfts.size > 0) { pfts(0)._2 } else { 0L }
+    }
+
+    val outTokens = if (isReplicationBoxPresent) {
+      val pfts = OUTPUTS(0).tokens.filter { (token: (Coll[Byte], Long)) =>
+        token._1 == pftTokenId
+      }
+      if (pfts.size > 0) { pfts(0)._2 } else { 0L }
+    } else {
+      0L // There is no self replicant box, so all the current PFT tokens are extracted.
+    }
+
+    // Return the difference between output tokens and self tokens
+    outTokens - selfTokens
+  }
+
+  val minimumReached: Boolean = {
+    val minimumSalesThreshold = selfMinimumTokensSold
+    val netSoldCounter = selfSoldCounter - selfRefundCounter  // Net sold counter (sold - refunded)
+
+    netSoldCounter >= minimumSalesThreshold
+  }
+
+
+  //  ACTIONS
+
+  // Validation for purchasing Tokens
+  // > People should be allowed to exchange base tokens for APT tokens until there are no more tokens left (even if the deadline has passed).
+  val isBuyTokens: SigmaProp = if (isSelfReplication) {
+
+    // Delta of tokens removed from the box
+    val deltaTokenRemoved = {
+      val outputAlreadyTokens = OUTPUTS(0).tokens(1)._2
+
+      selfAPT - outputAlreadyTokens
+    }
+
+    val onlyTemporaryUnsoldTokens = deltaTokenRemoved <= temporaryFundingTokenAmountOnContract(SELF)
+
+    // Verify if the base token amount matches the required exchange rate for the given token quantity
+    val correctExchange = {
+      val deltaBaseTokenAdded = getBaseTokenAmount(OUTPUTS(0)) - getBaseTokenAmount(SELF)
+      deltaBaseTokenAdded == deltaTokenRemoved * selfExchangeRate
+    }
+
+    // Verify if the token sold counter (R6)._1 is increased in proportion of the tokens sold.
+    val incrementSoldCounterCorrectly = {
+
+      // Calculate how much the sold counter is incremented.
+      val counterIncrement = {
+          // Obtain the current and the next "tokens sold counter"
+          val selfAlreadySoldCounter = selfSoldCounter
+          val outputAlreadySoldCounter = OUTPUTS(0).R6[Coll[Long]].get(0)
+
+          outputAlreadySoldCounter - selfAlreadySoldCounter
+      }
+
+      allOf(Coll(
+        deltaTokenRemoved == counterIncrement,
+        counterIncrement > 0 // This ensures that the increment is positive, if not, the buy action could be reversed.
+      ))
+    }
+
+    val constants = allOf(Coll(
+      isSelfReplication,                          // Replicate the contract will be needed always
+      // endOrReplicate,                          // The contract can't end with this action
+      // soldCounterRemainsConstant,              // The sold counter needs to be incremented.
+      refundCounterRemainsConstant,               // The refund counter must be constant
+      auxiliarExchangeCounterRemainsConstant,     // The auxiliar exchange counter must be constant because there is no exchange between APT -> PFT.
+      // mantainValue,                            // Needs to add value to the contract (for ERG) or maintain value (for tokens)
+      // APTokenRemainsConstant,                  // APT token is extracted from the contract.
+      ProofFundingTokenRemainsConstant           // PFT needs to be constant
+    ))
+
+    sigmaProp(allOf(Coll(
+      constants,
+      onlyTemporaryUnsoldTokens,     // Since the amount of APT is equal to the emission amount of PFT (+1), not necessarily equal to the contract amount, it must be ensured that the APT sold can be exchanged in the future.
+      correctExchange,               // Ensures that the proportion between the APTs and base token moved is the same following the R7 ratio.
+      incrementSoldCounterCorrectly  // Ensures that the R6 first value is incremented in proportion to the exchange value moved.
+    )))
+  } else { sigmaProp(false) }
+
+  // Validation for refunding tokens
+  val isRefundTokens: SigmaProp = if (isSelfReplication) {
+
+    // > People should be allowed to exchange tokens for base tokens if and only if the deadline has passed and the minimum number of tokens has not been sold.
+    val canBeRefund = {
+      // The minimum number of tokens has not been sold.
+      val minimumNotReached = !minimumReached
+
+      // Condition to check if the current height is beyond the block limit
+      val afterBlockLimit = {
+
+        val limit = selfBlockLimit._2
+
+        val now = if (selfBlockLimit._1) {
+          // If the first element is true, the limit is a timestamp
+          CONTEXT.preHeader.timestamp
+        } else {
+          // If the first element is false, the limit is a block height
+          HEIGHT.toLong
+        }
+
+        now > limit
+      }
+
+      afterBlockLimit && minimumNotReached
+    }
+
+    // Calculate the amount of tokens that the user adds to the contract.
+    val deltaTokenAdded = {
+      val outputAlreadyTokens = OUTPUTS(0).tokens(1)._2
+
+      outputAlreadyTokens - selfAPT
+    }
+
+    // Verify if the base token amount matches the required exchange rate for the returned token quantity
+    val correctExchange = {
+      val deltaBaseTokenReturned = getBaseTokenAmount(SELF) - getBaseTokenAmount(OUTPUTS(0))
+      val addedTokensValue = deltaTokenAdded * selfExchangeRate
+      deltaBaseTokenReturned == addedTokensValue
+    }
+
+    // Verify if the token refund counter (R6)._2 is increased in proportion of the tokens refunded.
+    val incrementRefundCounterCorrectly = {
+
+      // Calculate how much the refund counter is incremented.
+      val counterIncrement = {
+          // Obtain the current and the next "tokens refund counter"
+          val selfAlreadyRefundCounter = selfRefundCounter
+          val outputAlreadyRefundCounter = OUTPUTS(0).R6[Coll[Long]].get(1)
+
+          outputAlreadyRefundCounter - selfAlreadyRefundCounter
+      }
+
+      allOf(Coll(
+        deltaTokenAdded == counterIncrement,
+        counterIncrement > 0   // This ensures that the increment is positive, if not, the buy action could be reversed.
+      ))
+    }
+
+    val constants = allOf(Coll(
+      isSelfReplication,                          // Replicate the contract will be needed always
+      // endOrReplicate,                          // The contract can't end with this action
+      soldCounterRemainsConstant,                 // The sold counter needs to be constant.
+      // refundCounterRemainsConstant,            // Refund counter needs to be incremented.
+      auxiliarExchangeCounterRemainsConstant,     // Auxiliar counter needs to be constant.
+      // mantainValue,                            // Needs to extract value (for ERG) or maintain value (for tokens)
+      // APTokenRemainsConstant,                  // Needs to add Auxiliar tokens.
+      ProofFundingTokenRemainsConstant            // PFT needs to be constant.
+    ))
+
+    // The contract returns the equivalent base token value for the returned tokens
+    sigmaProp(allOf(Coll(
+      constants,
+      canBeRefund,                            // Ensures that the refund conditions are satisfied.
+      incrementRefundCounterCorrectly,        // Ensures increment the refund counter correctly in proportion with the exchanged amount.
+      correctExchange                         // Ensures that the value extracted and the APTs added are proportional following the R7 exchange ratio.
+    )))
+  } else { sigmaProp(false) }
+
+  // Validation for withdrawing funds by project owners
+  val isWithdrawFunds: SigmaProp = {
+    // Anyone can withdraw the funds to the project address.
+    // This is the only action that may end the campaign, and it may only do so by paying the owner
+    // and the dev fee what the split requires and retiring the NFT (#177).
+
+    // Calculate extracted amounts based on base token
+    val extractedBaseAmount: Long = if (isERGBase) {
+      // For ERG base token, extract ERG value
+      if (isReplicationBoxPresent) { selfValue - OUTPUTS(0).value } else { selfValue }
+    } else {
+      // For non-ERG base tokens, extract the token amount
+      val selfBaseTokens = getBaseTokenAmount(SELF)
+      val outputBaseTokens = if (isReplicationBoxPresent) getBaseTokenAmount(OUTPUTS(0)) else 0L
+      selfBaseTokens - outputBaseTokens
+    }
+
+    // Calculate dev fee and project amounts.
+    // Rounded up, and required to be positive below: v2 truncated, so on a token campaign any
+    // extraction of 19 units or fewer produced a fee of 0 and the fee could be avoided entirely by
+    // withdrawing in small enough slices (#177).
+    val devFeeAmount = (extractedBaseAmount * devFee + 99) / 100
+    val projectAmount = extractedBaseAmount - devFeeAmount
+
+    val feeIsPaid = extractedBaseAmount <= 0 || devFeeAmount > 0
+
+    val ownerOutputs = OUTPUTS.filter({(box: Box) => box.propositionBytes == ownerErgoTree})
+    val devFeeOutputs = OUTPUTS.filter({(box: Box) => blake2b256(box.propositionBytes) == devFeeContractBytesHash})
+
+    if (ownerOutputs.size > 0 && devFeeOutputs.size > 0) {
+      val ownerOutput = ownerOutputs(0)
+      val devFeeOutput = devFeeOutputs(0)
+
+      // Verify correct project amount
+      val correctProjectAmount = if (isERGBase) {
+        ownerOutput.value == projectAmount
+      }
+      else {
+        // For non-ERG tokens, verify the project receives correct token amount
+        val projectTokens = ownerOutput.tokens.filter { (token: (Coll[Byte], Long)) =>
+          token._1 == baseTokenId
+        }
+        val projectTokenAmount = if (projectTokens.size > 0) projectTokens(0)._2 else 0L
+        projectTokenAmount == projectAmount
+      }
+
+      // Verify correct dev fee
+      val correctDevFee = {
+
+        if (isERGBase) {
+          devFeeOutput.value == devFeeAmount
+        }
+
+        else {
+          // For non-ERG tokens, verify dev receives correct token amount
+          val devTokens = devFeeOutput.tokens.filter { (token: (Coll[Byte], Long)) =>
+            token._1 == baseTokenId
+          }
+          val devTokenAmount = if (devTokens.size > 0) devTokens(0)._2 else 0L
+          devTokenAmount == devFeeAmount
+        }
+      }
+
+      val endOrReplicate = {
+        val allFundsWithdrawn = if (isERGBase) extractedBaseAmount == selfValue else (extractedBaseAmount == getBaseTokenAmount(SELF))
+        val allTokensWithdrawn = SELF.tokens.exists({(pair: (Coll[Byte], Long)) => pair._1 == pftTokenId}) == false
+
+        // noExtraReplicas already makes "no box at OUTPUTS(0)" mean "no copy anywhere", so ended is
+        // redundant. It is kept as defence in depth, and because it is the check that makes the
+        // intent readable on its own.
+        val ended = replicas.size == 0
+
+        isSelfReplication || (ended && allFundsWithdrawn && allTokensWithdrawn && nftRetired)
+      }
+
+      val constants = allOf(Coll(
+        // isSelfReplication,
+        endOrReplicate,                             // Replicate the contract in case of partial withdraw
+        soldCounterRemainsConstant,                 // Any of the counter needs to be incremented, so all of them (sold, refund and exchange) need to remain constants.
+        refundCounterRemainsConstant,
+        auxiliarExchangeCounterRemainsConstant,
+        // mantainValue,                           // Needs to extract value from the contract
+        APTokenRemainsConstant,                    // There is no need to modify the auxiliar token, so it must be constant
+        ProofFundingTokenRemainsConstant           // There is no need to modify the proof of funding token, so it must be constant
+      ))
+
+      sigmaProp(allOf(Coll(
+        constants,
+        minimumReached,           // Project owners are allowed to withdraw base tokens if and only if the minimum number of tokens has been sold.
+        feeIsPaid,                // Ensures the fee cannot be rounded away to nothing.
+        correctDevFee,            // Ensures that the dev fee amount and dev address are correct
+        correctProjectAmount      // Ensures the correct project amount.
+      )))
+    }
+    else { sigmaProp(false) }
+  }
+
+  // > Project owners may withdraw unsold tokens from the contract at any time.
+  val isWithdrawUnsoldTokens: SigmaProp = {
+    // Calculate that only are sold the amount of PFT that are available, in other case, will be problems on the APT -> PFT exchange.
+    val onlyUnsold = {
+      // The amount of PFT token that has been extracted from the contract
+      val extractedPFT = -deltaPFTokenAdded
+      // Current APT tokens without the one used for project identification     (remember that the APT amount is equal to the PFT emission amount + 1, because the 1 is for be always inside the contract)
+      val temporalTokens = temporaryFundingTokenAmountOnContract(SELF)
+      // Only can extract an amount sufficient lower to allow the exchange APT -> PFT
+      extractedPFT <= temporalTokens
+    }
+
+    val constants = allOf(Coll(
+      isSelfReplication,                            // Restored from v1.2.0. Letting this action terminate left mantainValue
+                                                    // vacuous, so the owner could walk off with the whole balance without
+                                                    // paying the dev fee (#177). Termination belongs to isWithdrawFunds.
+      soldCounterRemainsConstant,                   // Any of the counter needs to be incremented, so all of them (sold, refund and exchange) need to remain constants.
+      refundCounterRemainsConstant,
+      auxiliarExchangeCounterRemainsConstant,
+      mantainValue,                                 // The value of the contract must not change.
+      APTokenRemainsConstant                        // APT token must be constant.
+      // ProofFundingTokenRemainsConstant           // The PFT is the token that the action tries to withdraw
+    ))
+
+    sigmaProp(allOf(Coll(
+      constants,
+      deltaPFTokenAdded < 0,  // A negative value means that PFT are extracted.
+      onlyUnsold  // Ensures that only extracts the token amount that has not been buyed.
+    ))) && ownerAuthentication  // Ensures that only extracts unsold PFTs the owner.   Not necesaryly to it's own address.
+  }
+
+  // > Project owners may add more tokens to the contract at any time.
+  val isAddTokens: SigmaProp = if (isReplicationBoxPresent) {
+
+    val constants = allOf(Coll(
+      isSelfReplication,                     // Replicate the contract will be needed always
+      // endOrReplicate,                     // The contract can't end with this action
+      soldCounterRemainsConstant,            // Any of the counter needs to be incremented, so all of them (sold, refund and exchange) need to remain constants.
+      refundCounterRemainsConstant,
+      auxiliarExchangeCounterRemainsConstant,
+      mantainValue,
+      APTokenRemainsConstant                 // There is no need to modify the APT amount because the amount is established in base of the PFT emission amount.
+      // ProofFundingTokenRemainsConstant,   // Adds PFT tokens, so can't remain constant
+    ))
+
+    sigmaProp(allOf(Coll(
+      constants,
+      deltaPFTokenAdded > 0   // Ensures that the tokens are added.
+    )) ) && ownerAuthentication
+  } else { sigmaProp(false) }
+
+  // Exchange APT (token that identies the project used as temporary funding token) with PFT (proof-of-funding token)
+  val isExchangeFundingTokens: SigmaProp = if (isReplicationBoxPresent) {
+
+    val deltaTemporaryFundingTokenAdded = {
+      val selfTFT = SELF.tokens(1)._2
+      val outTFT = OUTPUTS(0).tokens(1)._2
+
+      outTFT - selfTFT
+    }
+
+    val correctExchange = {
+
+      val deltaProofFundingTokenExtracted = -deltaPFTokenAdded
+
+      allOf(Coll(
+        deltaTemporaryFundingTokenAdded == deltaProofFundingTokenExtracted,
+        deltaTemporaryFundingTokenAdded > 0  // Ensures one way exchange (only send TFT and recive PFT)
+      ))
+    }
+
+      // Verify if the token auxiliar exchange counter (R6)._3 is increased in proportion of the tokens refunded.
+    val incrementExchangeCounterCorrectly = {
+
+      // Calculate how much the counter is incremented.
+      val counterIncrement = {
+          val selfAlreadyCounter = selfAuxiliarExchangeCounter
+          val outputAlreadyRefundCounter = OUTPUTS(0).R6[Coll[Long]].get(2)
+
+          outputAlreadyRefundCounter - selfAlreadyCounter
+      }
+
+      deltaTemporaryFundingTokenAdded == counterIncrement
+    }
+
+    val constants = allOf(Coll(
+      isSelfReplication,
+      soldCounterRemainsConstant,                           // Sold counter must be constant
+      refundCounterRemainsConstant,                         // Refund counter must be constant
+      // auxiliarExchangeCounterRemainsConstant,            // Auxiliar tokens are added to the contract to be exchanged with PFT
+      mantainValue                                          // ERG value must be constant
+      // APTokenRemainsConstant,                            // APT will change
+      // ProofFundingTokenRemainsConstant,                  // PFT will change
+    ))
+
+    sigmaProp(allOf(Coll(
+      constants,
+      minimumReached,                        // Only can exchange when the refund action is not, and will not be, possible
+      incrementExchangeCounterCorrectly,     // Ensures that the exchange counter is incremented in proportion to the APT added and the PFT extracted.
+      correctExchange                        // Ensures that the APT added and the PFT extracted amounts are equal.
+    )))
+  } else { sigmaProp(false) }
+
+  // Two invariants hold for every action, which is the point: in v2 each action decided for itself
+  // whether to look, and the one that forgot is what #174 walked through.
+  //   noExtraReplicas - at most one box with this script leaves the transaction
+  //   nftInReplica || nftRetired - the identity is in that box, or retired into an unspendable one
+  sigmaProp(noExtraReplicas && (nftInReplica || nftRetired)) && (
+    isBuyTokens ||
+    isRefundTokens ||
+    isWithdrawFunds ||
+    isWithdrawUnsoldTokens ||
+    isAddTokens ||
+    isExchangeFundingTokens
+  )
+}

--- a/contracts/mint_contract/mint_idt_v3.es
+++ b/contracts/mint_contract/mint_idt_v3.es
@@ -1,0 +1,47 @@
+{
+/*
+    The function of the following contract is to ensure that the minted token can be spent exclusively
+    in the contract corresponding to the constant 'contract_bytes_hash'.
+
+    v3 (#176): the project box now carries a singleton NFT at tokens(0) and the IDT/APT at tokens(1),
+    where v2 had the IDT at tokens(0) doing both jobs. The NFT is minted in this very transaction,
+    at no extra cost: on Ergo a newly minted token takes the id of INPUTS(0), and this box is input 0,
+    so the identity is pinned to a box that has just been spent and can never be reproduced.
+
+    This contract does not ensure:
+    1. The token amount should match the issuance amount of the PFT in the main contract.
+    2. Name, description, and decimal quantity aligned with the project and PFT.
+*/
+
+    val contractBox = OUTPUTS(0)
+
+    // The minted id is the id of INPUTS(0), so this box has to be input 0 for the check below to
+    // mean what it says.
+    val spentFirst = INPUTS(0).id == SELF.id
+
+    val correctSpend = {
+        val isIDT = SELF.tokens(0)._1 == contractBox.tokens(1)._1
+        val spendAll = SELF.tokens(0)._2 == contractBox.tokens(1)._2
+
+        isIDT && spendAll
+    }
+
+    // The project NFT: minted here, a singleton, and at the index the contract reads identity from.
+    val correctNft = {
+        val isMintedHere = contractBox.tokens(0)._1 == SELF.id
+        val isSingleton = contractBox.tokens(0)._2 == 1L
+
+        isMintedHere && isSingleton
+    }
+
+    val correctContract = {
+        fromBase16("`+contract_bytes_hash+`") == blake2b256(contractBox.propositionBytes)
+    }
+
+    sigmaProp(allOf(Coll(
+        spentFirst,
+        correctSpend,
+        correctNft,
+        correctContract
+    )))
+}

--- a/src/lib/common/project.ts
+++ b/src/lib/common/project.ts
@@ -61,7 +61,15 @@ export interface Project {
     version: contract_version,
     platform: Platform,
     box: Box<Amount>,
+    /**
+     * What identifies the campaign: the singleton NFT from v3 on, the APT before that.
+     *
+     * Keep using this for identity and for URLs. For the token that has to be moved in and out of
+     * the box, use {@link apt_token_id} - from v3 they are two different tokens.
+     */
     project_id: string,
+    /** The APT, the token contributors receive and hand back. `project_id` before v3. */
+    apt_token_id: string,
     current_idt_amount: number,
     pft_token_id: string,
     base_token_id: string,  // Base token ID for contributions (empty string for ERG)

--- a/src/lib/common/project.ts
+++ b/src/lib/common/project.ts
@@ -84,6 +84,19 @@ export interface Project {
     constants: ConstantContent
 }
 
+/**
+ * Whether a project runs on an older contract than the one the platform deploys today.
+ *
+ * Written as a comparison against `last_version` rather than a list of old versions, so that
+ * publishing a new contract marks its predecessor without anyone having to remember to come back
+ * here. It matters for #176: the versions this returns true for are the ones with no on-chain
+ * identity beyond a circulating token, so a campaign on one is worth a second look before it is
+ * funded.
+ */
+export function is_legacy_version(project: Project): boolean {
+    return project.version !== project.platform.last_version;
+}
+
 export async function is_ended(project: Project): Promise<boolean> {
     if (project.is_timestamp_limit) {
         // In timestamp mode, compare with current time

--- a/src/lib/components/LegacyContractBadge.svelte
+++ b/src/lib/components/LegacyContractBadge.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import { badgeVariants } from "$lib/components/ui/badge";
+    import { is_legacy_version, type Project } from "$lib/common/project";
+
+    export let project: Project;
+    /** Compact form for cards, where the row is already crowded. */
+    export let compact: boolean = false;
+
+    $: isLegacy = is_legacy_version(project);
+    $: label = project.version.replace("_", ".");
+
+    const explanation =
+        "This campaign runs on an older version of the contract. Check the project's " +
+        "own channels before contributing, and prefer campaigns on the current contract.";
+</script>
+
+{#if isLegacy}
+    <a
+        href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"
+        target="_blank"
+        rel="noopener noreferrer"
+        title={explanation}
+        class="{badgeVariants({
+            variant: 'outline',
+        })} legacy-badge"
+    >
+        {compact ? `Legacy ${label}` : `Legacy contract ${label}`}
+    </a>
+{/if}
+
+<style>
+    .legacy-badge {
+        border-color: rgba(234, 179, 8, 0.6);
+        color: rgb(202, 138, 4);
+        background-color: rgba(234, 179, 8, 0.1);
+        white-space: nowrap;
+    }
+
+    :global(.dark) .legacy-badge {
+        color: rgb(250, 204, 21);
+    }
+</style>

--- a/src/lib/ergo/actions/buy_refund.ts
+++ b/src/lib/ergo/actions/buy_refund.ts
@@ -9,6 +9,7 @@ import {
 import { SString } from '../utils';
 import { createR8Structure, type Project } from '../../common/project';
 import { get_ergotree_hex } from '../contract';
+import { addIdentityTokens } from '../replica';
 import { getCurrentHeight, getChangeAddress, signTransaction, submitTransaction, getUtxos } from 'wallet-svelte-component';
 import { SBool, SColl, SPair } from '@fleet-sdk/serializer';
 
@@ -45,10 +46,12 @@ export async function buy_refund(
         let hasRequiredTokens = false;
 
 
+        // What a contributor holds and hands back is the APT, not the project id: from v3 on the
+        // project id is the NFT, which never leaves the box.
         for (const utxo of walletUtxos) {
             if (utxo.assets && utxo.assets.length > 0) {
                 for (const asset of utxo.assets) {
-                    if (asset.tokenId === project.project_id) {
+                    if (asset.tokenId === project.apt_token_id) {
                         if (Number(asset.amount) >= requiredTokenAmount) {
                             hasRequiredTokens = true;
                             break;
@@ -85,11 +88,9 @@ export async function buy_refund(
     let output = new OutputBuilder(
         BigInt(contractErgValue).toString(),
         get_ergotree_hex(project.constants, project.version)
-    )
-        .addTokens({
-            tokenId: project.project_id,
-            amount: BigInt(project.current_idt_amount - token_amount).toString()  // Buy: extract tokens, Refund: add tokens
-        });
+    );
+    // Buy: extract APT, Refund: add it back. The NFT stays put either way.
+    addIdentityTokens(output, project, BigInt(project.current_idt_amount - token_amount));
 
     // Add PFT tokens if they exist
     if (project.current_pft_amount > 0) {
@@ -155,9 +156,10 @@ export async function buy_refund(
     // Create user outputs based on action type
     if (token_amount > 0) {
         // Buy: user gets project tokens
+        // What the contributor receives is the APT, which is not the project id from v3 on.
         let userOutput = new OutputBuilder(SAFE_MIN_BOX_VALUE, walletPk)
             .addTokens({
-                tokenId: project.project_id,
+                tokenId: project.apt_token_id,
                 amount: token_amount.toString()
             });
         outputs.push(userOutput);

--- a/src/lib/ergo/actions/rebalance.ts
+++ b/src/lib/ergo/actions/rebalance.ts
@@ -10,6 +10,7 @@ import {
 import { SString } from '../utils';
 import { createR8Structure, type Project } from '../../common/project';
 import { get_ergotree_hex } from '../contract';
+import { addIdentityTokens } from '../replica';
 import { getCurrentHeight, getChangeAddress, signTransaction, submitTransaction, getUtxos } from 'wallet-svelte-component';
 import { SBool, SColl, SPair } from '@fleet-sdk/serializer';
 
@@ -35,11 +36,8 @@ export async function rebalance(
         let contract_output = new OutputBuilder(
             BigInt(project.value),
             get_ergotree_hex(project.constants, project.version)
-        )
-            .addTokens({
-                tokenId: project.project_id,
-                amount: BigInt(project.current_idt_amount)
-            });
+        );
+        addIdentityTokens(contract_output, project, BigInt(project.current_idt_amount));
 
         console.log("PFT current amount " + project.current_pft_amount / Math.pow(10, project.token_details.decimals))
         let contract_token_amount = project.current_pft_amount + token_amount;

--- a/src/lib/ergo/actions/submit.ts
+++ b/src/lib/ergo/actions/submit.ts
@@ -10,6 +10,7 @@ import {
 import { SBool, SColl, SPair } from '@fleet-sdk/serializer';
 import { SString } from '../utils';
 import { type contract_version, get_ergotree_hex, mint_contract_address } from '../contract';
+import { buildProjectOutput, project_token_count } from '../replica';
 import { createR8Structure, type ConstantContent } from '$lib/common/project';
 import { get_dev_contract_address, get_dev_contract_hash, get_dev_fee } from '../dev/dev_contract';
 import { fetch_token_details } from '../fetch';
@@ -114,13 +115,15 @@ export async function* submit_project(
     // CRITICAL: token id determinism.
     // The minted token id MUST equal the boxId of the FIRST input of the minting transaction.
     // We explicitly pick and lock `issuanceBox` to guarantee both:
-    // - `project_id` correctness, and
+    // - the APT id being what the project box will declare, and
     // - `issuanceBox` is actually the first input passed to FleetSDK.
     const issuanceBox = walletUtxos[0];
     const mintInputs = [issuanceBox, ...walletUtxos.filter((b: any) => b.boxId !== issuanceBox.boxId)];
 
     // Token id of an issued token is always the boxId of the first input of the issuance transaction.
-    const project_id = issuanceBox.boxId;
+    // From v3 this is the APT only: identity moved to a separate NFT, minted in Tx B, whose id is
+    // the mint box's - see below.
+    const apt_token_id = issuanceBox.boxId;
 
     const r4Hex = SPair(SBool(is_timestamp_limit), SLong(BigInt(blockLimit))).toHex();
     const r5Hex = SLong(BigInt(minimumSold)).toHex();
@@ -138,14 +141,18 @@ export async function* submit_project(
     // CRITICAL: never use placeholder token ids (e.g. `token_id ?? ""`) because it can create invalid boxes.
     // Base token id is a *parameter* (in R8) and is not required to be present in the box at creation.
     const projectTokens: Array<{ tokenId: string; amount: bigint }> = [
-        { tokenId: project_id, amount: BigInt(id_token_amount) },
+        { tokenId: apt_token_id, amount: BigInt(id_token_amount) },
         { tokenId: token_id, amount: BigInt(token_amount) }
     ];
+
+    // v3 carries one token more than the list above: the project NFT, minted in Tx B and placed at
+    // index 0 by the builder, so it does not appear here but does take up room.
+    const tokenCount = project_token_count(version, projectTokens.length);
 
     // Estimate total box size
     const totalEstimatedSize = estimateTotalBoxSize(
         ergoTreeAddress.length,
-        projectTokens.length,
+        tokenCount,
         registerSizes
     );
 
@@ -167,19 +174,15 @@ export async function* submit_project(
     });
 
     // Tx B output #0: campaign/project box. This must be OUTPUTS(0) for `mint_idt.es` validation.
-    const projectOutput = new OutputBuilder(
-        minRequiredValue,
-        ergoTreeAddress
-    )
-        .addTokens(projectTokens)
-        .setAdditionalRegisters({
-            R4: r4Hex,
-            R5: r5Hex,
-            R6: r6Hex,
-            R7: r7Hex,
-            R8: r8Hex,
-            R9: r9Hex
-        });
+    // tests/contracts/v3_creation.test.ts runs this same builder against the compiled contracts.
+    const projectOutput = buildProjectOutput({
+        version,
+        value: minRequiredValue,
+        ergoTree: ergoTreeAddress,
+        title,
+        tokens: projectTokens,
+        registers: { R4: r4Hex, R5: r5Hex, R6: r6Hex, R7: r7Hex, R8: r8Hex, R9: r9Hex }
+    });
 
     // Build a chained bundle (Tx A -> Tx B). Wallet signs once.
     const unsignedTransactions = await new TransactionBuilder(await getCurrentHeight())

--- a/src/lib/ergo/actions/temp_exchange.ts
+++ b/src/lib/ergo/actions/temp_exchange.ts
@@ -9,7 +9,8 @@ import {
 
 import { SString } from '../utils';
 import { createR8Structure, type Project } from '../../common/project';
-import { get_ergotree_hex } from '../contract';
+import { get_ergotree_hex, supports_base_token } from '../contract';
+import { addIdentityTokens } from '../replica';
 import { getCurrentHeight, getChangeAddress, signTransaction, submitTransaction, getUtxos } from 'wallet-svelte-component';
 import { SBool, SColl, SPair } from '@fleet-sdk/serializer';
 
@@ -31,11 +32,9 @@ export async function temp_exchange(
     let contractOutput = new OutputBuilder(
         BigInt(project.value),
         get_ergotree_hex(project.constants, project.version)
-    )
-        .addTokens({
-            tokenId: project.project_id,
-            amount: BigInt(project.current_idt_amount + token_amount)
-        });
+    );
+    // The exchange hands APT back to the box in return for PFT.
+    addIdentityTokens(contractOutput, project, BigInt(project.current_idt_amount + token_amount));
 
     if (project.current_pft_amount !== token_amount) {
         contractOutput.addTokens({
@@ -45,7 +44,7 @@ export async function temp_exchange(
     }
 
     // Handle base tokens for v2 multitoken contracts
-    if (project.version === "v2" && project.base_token_id && project.base_token_id !== "") {
+    if (supports_base_token(project.version) && project.base_token_id && project.base_token_id !== "") {
         // Find current base token amount in the project box
         let currentBaseTokenAmount = 0;
         for (const token of project.box.assets) {

--- a/src/lib/ergo/actions/withdraw.ts
+++ b/src/lib/ergo/actions/withdraw.ts
@@ -7,7 +7,8 @@ import {
 } from '@fleet-sdk/core';
 import { SString } from '../utils';
 import { createR8Structure, type Project } from '../../common/project';
-import { get_ergotree_hex } from '../contract';
+import { get_ergotree_hex, supports_base_token } from '../contract';
+import { addIdentityTokens, dev_fee_for } from '../replica';
 import { getCurrentHeight, getChangeAddress, signTransaction, submitTransaction, getUtxos } from 'wallet-svelte-component';
 import { get_dev_contract_address } from '../dev/dev_contract';
 import { SColl, SPair, SByte, SBool } from '@fleet-sdk/serializer';
@@ -19,17 +20,23 @@ export async function withdraw(
 ): Promise<string | null> {
 
     // Check if this is a multi-token contract (v2) with a base token
-    const isMultiToken = project.version === "v2" && project.base_token_id && project.base_token_id !== "";
+    const isMultiToken = supports_base_token(project.version) && project.base_token_id && project.base_token_id !== "";
     const isERGBase = !isMultiToken;
 
-    // Convert amount to smallest unit
+    // Convert amount to smallest unit.
+    //
+    // Rounded, because the multiplication does not land on an integer for a good share of ordinary
+    // inputs - 1.07 ERG gives 1070000000.0000001, 2.01 gives 2009999999.9999998 - and everything
+    // downstream turns these into BigInt, which throws on anything fractional. Rounding rather
+    // than truncating, so that 2.01 means 2010000000 and not one nanoERG less. The other actions
+    // already guard this multiplication; this one did not.
     if (isERGBase) {
         // For ERG-based contracts, convert to nanoERG
-        amount = amount * Math.pow(10, 9);
+        amount = Math.round(amount * Math.pow(10, 9));
     } else {
         // For token-based contracts, convert to smallest unit using token decimals
         const baseTokenDecimals = project.base_token_details?.decimals || 0;
-        amount = amount * Math.pow(10, baseTokenDecimals);
+        amount = Math.round(amount * Math.pow(10, baseTokenDecimals));
     }
 
     console.log("wants withdraw ", amount, isERGBase ? "(ERG)" : "(base token)")
@@ -75,13 +82,9 @@ export async function withdraw(
         }
     }
 
-    // Calculate dev fee and project amounts according to contract logic
-    let devFeeAmount = Math.floor(extractedBaseAmount * devFeePercentage / 100);
-
-    // Apply contract logic: if devFeeAmount < 1, set to 0
-    if (devFeeAmount < 1) {
-        devFeeAmount = 0;
-    }
+    // The fee is whatever the contract of THIS box computes - v3 rounds up, v2 and earlier
+    // truncate. See dev_fee_for and #177.
+    const devFeeAmount = Number(dev_fee_for(extractedBaseAmount, devFeePercentage, project.version));
 
     const projectAmountBase = extractedBaseAmount - devFeeAmount;
 
@@ -132,10 +135,9 @@ export async function withdraw(
         const contractOutput = new OutputBuilder(
             remainingErg,
             get_ergotree_hex(project.constants, project.version)
-        ).addTokens({
-            tokenId: project.project_id,
-            amount: BigInt(project.current_idt_amount) // APT remains constant
-        });
+        );
+        // The APT is untouched by a withdrawal; the NFT rides along in v3.
+        addIdentityTokens(contractOutput, project, BigInt(project.current_idt_amount));
 
         // Add PFT tokens if they exist (ProofFundingTokenRemainsConstant)
         if (project.current_pft_amount > 0) {

--- a/src/lib/ergo/contract.ts
+++ b/src/lib/ergo/contract.ts
@@ -10,11 +10,51 @@ import { get_dev_contract_address, get_dev_contract_hash, get_dev_fee } from "./
 import CONTRACT_V1_0 from '../../../contracts/bene_contract/contract_v1_0.es?raw';
 import CONTRACT_V1_1 from '../../../contracts/bene_contract/contract_v1_1.es?raw';
 
-// Current version contract
 import CONTRACT_V2 from '../../../contracts/bene_contract/contract_v2.es?raw';
 import MINT_CONTRACT from '../../../contracts/mint_contract/mint_idt.es?raw';
 
-export type contract_version = "v2" | "v1_1" | "v1_0";
+// Current version contract
+import CONTRACT_V3 from '../../../contracts/bene_contract/contract_v3.es?raw';
+import MINT_CONTRACT_V3 from '../../../contracts/mint_contract/mint_idt_v3.es?raw';
+
+export type contract_version = "v3" | "v2" | "v1_1" | "v1_0";
+
+/**
+ * The versions whose source the platform still compiles, newest first.
+ *
+ * Order matters where a box has to be identified: a v3 box parses as v3 and nothing else, but the
+ * search is cheapest when the current version is tried first.
+ */
+export const CONTRACT_VERSIONS: contract_version[] = ["v3", "v2", "v1_1", "v1_0"];
+
+/**
+ * Where the project's own identity lives in `tokens`.
+ *
+ * v3 puts a singleton NFT at index 0 and moves the APT to index 1; before that the APT sat at
+ * index 0 and did both jobs, which is the whole of #176. Every other token keeps its position
+ * relative to the APT, so one offset describes the difference.
+ */
+export function has_project_nft(version: contract_version): boolean {
+  return version === "v3";
+}
+
+/**
+ * Whether the version can denominate a campaign in a token other than ERG.
+ *
+ * Introduced in v2 and kept in v3. Written as a predicate because the check used to be spelled
+ * `version === "v2"` at each call site, which silently excluded every later version.
+ */
+export function supports_base_token(version: contract_version): boolean {
+  return version === "v2" || version === "v3";
+}
+
+/**
+ * Whether R4 holds the `(Boolean, Long)` deadline tuple rather than a bare block height.
+ * v1 stored an Int; v2 introduced the tuple and v3 keeps it.
+ */
+export function has_deadline_tuple(version: contract_version): boolean {
+  return version === "v2" || version === "v3";
+}
 
 function generate_contract_v1_0(owner_addr: string, dev_fee_contract_bytes_hash: string, dev_fee: number, token_id: string) {
   return CONTRACT_V1_0
@@ -32,11 +72,15 @@ function generate_contract_v1_1(owner_addr: string, dev_fee_contract_bytes_hash:
     .replace(/`\+token_id\+`/g, token_id);
 }
 
-/**
- * Generate v2 contract (current version)
- */
 function generate_contract_v2(): string {
   return CONTRACT_V2;
+}
+
+/**
+ * Generate v3 contract (current version)
+ */
+function generate_contract_v3(): string {
+  return CONTRACT_V3;
 }
 
 function handle_contract_generator(version: contract_version) {
@@ -51,6 +95,9 @@ function handle_contract_generator(version: contract_version) {
     case "v2":
       f = generate_contract_v2;
       break;
+    case "v3":
+      f = generate_contract_v3;
+      break;
     default:
       throw new Error("Invalid contract version");
   }
@@ -58,13 +105,47 @@ function handle_contract_generator(version: contract_version) {
 }
 
 /**
- * Get ErgoTree hex for current version contracts only (v2)
+ * The source a constant-free version compiles from.
+ *
+ * v2 and v3 carry no per-project constants, so their source is the contract itself. v1_0 and v1_1
+ * substituted the owner and the fee into the script, which is why they are not here: a v1 replica
+ * cannot be rebuilt without the constants, and the platform has not created one for a long time.
+ */
+function constant_free_source(version: contract_version): string {
+  switch (version) {
+    case "v3":
+      return CONTRACT_V3;
+    case "v2":
+      return CONTRACT_V2;
+    default:
+      throw new Error(
+        `Cannot rebuild a ${version} box: its script depends on constants that are not recoverable here`
+      );
+  }
+}
+
+/**
+ * Compiling a contract is expensive and its result never changes, so each version is compiled
+ * once. This matters now that every box the platform reads is checked against the script of the
+ * version it claims: without the cache that is one compilation per box per scan.
+ */
+const ergotree_cache = new Map<contract_version, string>();
+
+/**
+ * Get ErgoTree hex for the version of the box being rebuilt.
+ *
+ * Every action that replicates a project box passes the version of the box it is spending, not the
+ * version the platform currently deploys: a v2 campaign has to keep replicating as v2, or the
+ * contract's own `sameScript` check rejects the transaction.
  */
 export function get_ergotree_hex(constants: ConstantContent, version: contract_version) {
-  const contract = generate_contract_v2();
+  const cached = ergotree_cache.get(version);
+  if (cached) return cached;
 
-  const ergoTree = compile(contract, { version: 1, network: network_id });
-  return ergoTree.toHex();
+  const ergoTree = compile(constant_free_source(version), { version: 1, network: network_id });
+  const hex = ergoTree.toHex();
+  ergotree_cache.set(version, hex);
+  return hex;
 }
 
 /**
@@ -82,8 +163,8 @@ export function get_template_hash(version: contract_version): string {
   }
 
   let contract;
-  if (version === "v2") {
-    contract = CONTRACT_V2;
+  if (version === "v2" || version === "v3") {
+    contract = constant_free_source(version);
   } else {
     contract = handle_contract_generator(version)(random_constants.owner, random_constants.dev_hash ?? get_dev_contract_hash(), random_constants.dev_fee, random_constants.pft_token_id);
   }
@@ -94,13 +175,12 @@ export function get_template_hash(version: contract_version): string {
 }
 
 /**
- * Get contract hash for v2 contracts only
+ * Blake2b-256 of the proposition bytes of `version`'s contract - what the mint contract compares
+ * OUTPUTS(0) against, so that the minted tokens can only be spent into the real project box.
  */
 function get_contract_hash(constants: ConstantContent, version: contract_version): string {
   try {
-    const contractSource = generate_contract_v2();
-
-    const ergoTree = compile(contractSource, {
+    const ergoTree = compile(constant_free_source(version), {
       version: 1,
       network: network_id
     });
@@ -113,11 +193,16 @@ function get_contract_hash(constants: ConstantContent, version: contract_version
 }
 
 /**
- * Get mint contract address for v2 contracts only
+ * Get the mint contract address for the version being created.
+ *
+ * v3 mints two things in Tx B rather than one - the project NFT alongside the APT - so it has its
+ * own mint contract; pairing a v3 project with the v2 mint contract would create a box with no NFT
+ * at tokens(0), which v3 rejects.
  */
 export function mint_contract_address(constants: ConstantContent, version: contract_version) {
   const contract_bytes_hash = get_contract_hash(constants, version);
-  let contract = MINT_CONTRACT.replace(/`\+contract_bytes_hash\+`/g, contract_bytes_hash);
+  const source = version === "v3" ? MINT_CONTRACT_V3 : MINT_CONTRACT;
+  let contract = source.replace(/`\+contract_bytes_hash\+`/g, contract_bytes_hash);
 
   let ergoTree = compile(contract, { version: 1, network: network_id })
 

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -6,6 +6,7 @@ import { type contract_version, get_template_hash } from "./contract";
 import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
 import { get } from "svelte/store";
 import { get_dev_contract_hash, get_dev_fee } from "./dev/dev_contract";
+import { resolveCanonicalBox } from "./lineage";
 
 const expectedSigmaTypesV1 = {
     R4: 'SInt',
@@ -62,6 +63,33 @@ function clearConflict(projectId: string) {
         next.delete(projectId);
         return next;
     });
+}
+
+/**
+ * Which of several boxes claiming one project id descends from the mint, or null when that cannot
+ * be established.
+ *
+ * This is the "canonical-box resolution by lineage" the note above points at. It answers the
+ * question the box itself cannot: the APT says which campaign a box claims to be, and the walk
+ * from the mint says which box the campaign actually is. Only called on an actual collision, so
+ * the extra explorer calls are not paid for on every project of every sweep.
+ */
+async function resolveByLineage<T extends { box: { boxId: string } }>(
+    projectId: string,
+    candidates: T[]
+): Promise<T | null> {
+    try {
+        const { box, ended } = await resolveCanonicalBox(projectId);
+        if (ended) {
+            console.warn(`Project ${projectId} has ended on chain; the boxes claiming it are leftovers`);
+        }
+        // With no canonical box - ended, or not resolvable - `box?.boxId` is undefined and matches
+        // no candidate, which is the answer wanted in both cases: none of these is the campaign.
+        return candidates.find((c) => c.box.boxId === box?.boxId) ?? null;
+    } catch (error) {
+        console.warn(`Could not resolve the lineage of ${projectId}:`, error);
+        return null;
+    }
 }
 
 function hasValidSigmaTypes(additionalRegisters: any, version: contract_version): boolean {
@@ -180,6 +208,9 @@ export async function fetchProjectsFromBlockchain() {
     // active campaign as a conflict.
     const boxIdByProject = new Map<string, string>();
     const conflicts = new Map<string, string[]>();
+    // The parsed project behind each box id above, so that a collision can be settled in favour of
+    // whichever of the two the lineage points at without parsing it again.
+    const seenThisSweep = new Map<string, Project>();
 
     try {
         for (const version of versions) {
@@ -226,18 +257,33 @@ export async function fetchProjectsFromBlockchain() {
 
                     const knownBoxId = boxIdByProject.get(project.project_id);
                     if (knownBoxId !== undefined && knownBoxId !== project.box.boxId) {
-                        const boxIds = conflicts.get(project.project_id) ?? [knownBoxId];
-                        if (!boxIds.includes(project.box.boxId)) boxIds.push(project.box.boxId);
-                        conflicts.set(project.project_id, boxIds);
+                        const rival = seenThisSweep.get(project.project_id);
+                        const winner = rival
+                            ? await resolveByLineage(project.project_id, [rival, project])
+                            : null;
 
-                        // Drop the one already listed instead of replacing it: neither can be trusted.
                         const current = get(projects).data;
-                        current.delete(project.project_id);
+                        if (winner) {
+                            // The chain settles it: one of them descends from the mint and the
+                            // other does not, so the campaign can be listed instead of hidden.
+                            conflicts.delete(project.project_id);
+                            boxIdByProject.set(project.project_id, winner.box.boxId);
+                            seenThisSweep.set(project.project_id, winner);
+                            current.set(project.project_id, winner);
+                        } else {
+                            const boxIds = conflicts.get(project.project_id) ?? [knownBoxId];
+                            if (!boxIds.includes(project.box.boxId)) boxIds.push(project.box.boxId);
+                            conflicts.set(project.project_id, boxIds);
+
+                            // Drop the one already listed instead of replacing it: neither can be trusted.
+                            current.delete(project.project_id);
+                        }
                         projects.set({ data: current, last_fetch: get(projects).last_fetch });
                         continue;
                     }
 
                     boxIdByProject.set(project.project_id, project.box.boxId);
+                    seenThisSweep.set(project.project_id, project);
                     const current = get(projects).data;
                     current.set(project.project_id, project)
                     projects.set({ data: current, last_fetch: get(projects).last_fetch });
@@ -258,6 +304,26 @@ export async function fetchProjectsFromBlockchain() {
 export async function fetchProjectById(projectId: string): Promise<Project | null> {
     console.log(`Fetching project by ID: ${projectId}`);
     const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
+
+    // This is the page someone reads before sending money, so identity is established from the
+    // chain rather than taken on trust from a circulating token: walk from the mint and see which
+    // box that reaches. Unlike the listing sweep, one campaign is worth the round trips - and the
+    // walk is cached, so a second visit costs one call. See #176.
+    let lineage: { boxId: string | null; ended: boolean } | null = null;
+    try {
+        const { box, ended } = await resolveCanonicalBox(projectId);
+        lineage = { boxId: box?.boxId ?? null, ended };
+    } catch (error) {
+        console.warn(`Could not resolve the lineage of ${projectId}:`, error);
+    }
+
+    if (lineage?.ended) {
+        // The chain that starts at the mint has terminated: whatever still carries this token is
+        // a leftover, not the campaign. This is the #174 shape, where the closing transaction also
+        // left a copy behind.
+        console.warn(`Project ${projectId} has ended on chain; not displaying a leftover box`);
+        return null;
+    }
 
     try {
          const url = get(explorer_uri) + '/api/v1/boxes/unspent/byTokenId/' + projectId;
@@ -291,6 +357,25 @@ export async function fetchProjectById(projectId: string): Promise<Project | nul
              }
          }
 
+         if (lineage?.boxId) {
+             const canonical = candidates.find((p) => p.box.boxId === lineage!.boxId);
+             if (canonical) {
+                 clearConflict(projectId);
+                 return canonical;
+             }
+             // The box the chain points at is not among the unspent ones. Whatever is here
+             // instead is not the campaign, however plausible it parses.
+             if (candidates.length > 1) {
+                 recordConflict(projectId, candidates.map((p) => p.box.boxId));
+             }
+             console.warn(
+                 `The canonical box ${lineage.boxId} of ${projectId} is not among the unspent boxes`
+             );
+             return null;
+         }
+
+         // The lineage could not be resolved at all - no such token, or the explorer did not
+         // answer. Fall back to refusing a tie, which is where this stood before #176.
          if (candidates.length > 1) {
              recordConflict(projectId, candidates.map((p) => p.box.boxId));
              return null;

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -2,7 +2,7 @@ import { type Box, SAFE_MIN_BOX_VALUE } from "@fleet-sdk/core";
 import { type ConstantContent, type Project, type TokenEIP4, getConstantContent, getProjectContent } from "../common/project";
 import { ErgoPlatform } from "./platform";
 import { hexToUtf8 } from "./utils";
-import { type contract_version, get_template_hash } from "./contract";
+import { type contract_version, get_template_hash, get_ergotree_hex, CONTRACT_VERSIONS, has_project_nft, has_deadline_tuple } from "./contract";
 import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
 import { get } from "svelte/store";
 import { get_dev_contract_hash, get_dev_fee } from "./dev/dev_contract";
@@ -17,6 +17,7 @@ const expectedSigmaTypesV1 = {
     R9: 'Coll[SByte]'
 };
 
+// v3 changed the token layout, not the registers, so it validates against the same shape as v2.
 const expectedSigmaTypesV2 = {
     R4: '(SBoolean, SLong)',
     R5: 'SLong',
@@ -94,7 +95,7 @@ async function resolveByLineage<T extends { box: { boxId: string } }>(
 
 function hasValidSigmaTypes(additionalRegisters: any, version: contract_version): boolean {
     if (!additionalRegisters) return false;
-    const expectedTypes = version === "v2" ? expectedSigmaTypesV2 : expectedSigmaTypesV1;
+    const expectedTypes = (version === "v2" || version === "v3") ? expectedSigmaTypesV2 : expectedSigmaTypesV1;
     for (const [key, expectedType] of Object.entries(expectedTypes)) {
         // Check if register exists AND has correct type
         if (!additionalRegisters[key] || additionalRegisters[key].sigmaType !== expectedType) {
@@ -200,7 +201,7 @@ export async function fetchProjectsFromBlockchain() {
     const registers = {};
     let moreDataAvailable;
 
-    const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
+    const versions: contract_version[] = [...CONTRACT_VERSIONS];
 
     // Box id seen for each project id during THIS sweep. It cannot be read off the `projects`
     // store: a non-forced refetch keeps the previous entries, whose box ids are legitimately
@@ -303,7 +304,7 @@ export async function fetchProjectsFromBlockchain() {
 
 export async function fetchProjectById(projectId: string): Promise<Project | null> {
     console.log(`Fetching project by ID: ${projectId}`);
-    const versions: contract_version[] = ["v2", "v1_1", "v1_0"];
+    const versions: contract_version[] = [...CONTRACT_VERSIONS];
 
     // This is the page someone reads before sending money, so identity is established from the
     // chain rather than taken on trust from a circulating token: walk from the mint and see which
@@ -396,6 +397,27 @@ export async function fetchProjectById(projectId: string): Promise<Project | nul
     }
 }
 
+/**
+ * Whether the box is actually locked by `version`'s script.
+ *
+ * The registers do not tell versions apart on their own, and neither do the tokens: a v2 campaign
+ * that has sold out holds exactly 1 APT - the +1 the contract keeps so the token is always present
+ * - which looks exactly like v3's singleton NFT. The script is what distinguishes them, and it is
+ * the same check the contract itself makes when it replicates.
+ *
+ * Only checkable for the versions whose source carries no per-project constants; a v1 script
+ * cannot be rebuilt from the box, so those are left to the register shapes as before.
+ */
+function locked_by_version(e: any, version: contract_version, constants: ConstantContent): boolean {
+    if (version !== "v2" && version !== "v3") return true;
+    try {
+        return e.ergoTree === get_ergotree_hex(constants, version);
+    } catch (error) {
+        console.warn(`Could not rebuild the ${version} script to check box ${e.boxId}:`, error);
+        return false;
+    }
+}
+
 async function parseProjectBox(e: any, version: contract_version): Promise<Project | null> {
     if (hasValidSigmaTypes(e.additionalRegisters, version)) {
         let constants: ConstantContent | null = null;
@@ -438,7 +460,21 @@ async function parseProjectBox(e: any, version: contract_version): Promise<Proje
             }
         }
 
+        if (!locked_by_version(e, version, constants)) return null;
+
+        // From v3 the box carries a singleton NFT at index 0 and the APT at index 1; before that
+        // the APT sat at index 0 and did both jobs. The NFT is what makes a v3 box identifiable
+        // without walking its lineage, so its amount is checked here rather than assumed: a box
+        // whose "NFT" has any other amount is not a v3 project, whatever else it looks like.
+        const nft = has_project_nft(version);
+        if (nft && (e.assets.length < 2 || Number(e.assets[0].amount) !== 1)) {
+            console.warn(`Box ${e.boxId} claims to be ${version} but carries no singleton at tokens(0)`);
+            return null;
+        }
+        const aptIndex = nft ? 1 : 0;
         let project_id = e.assets[0].tokenId;
+        let apt_token_id = e.assets[aptIndex].tokenId;
+        let current_idt_amount = e.assets[aptIndex].amount;
         let token_id = constants.pft_token_id;
         let [token_amount_sold, refunded_token_amount, auxiliar_exchange_counter] = JSON.parse(e.additionalRegisters.R6.renderedValue);
 
@@ -455,7 +491,7 @@ async function parseProjectBox(e: any, version: contract_version): Promise<Proje
 
         let block_limit: number = 0;
         let is_timestamp_limit = false;
-        if (version === "v2") {
+        if (has_deadline_tuple(version)) {
             const r4Value = JSON.parse(e.additionalRegisters.R4?.renderedValue.replace(/\[([a-f0-9]+)(,.*)/, '["$1"$2'));
             if (!Array.isArray(r4Value) || r4Value.length < 2) throw new Error("R4 is not a valid tuple (Type, Deadline).");
 
@@ -492,7 +528,8 @@ async function parseProjectBox(e: any, version: contract_version): Promise<Proje
                 transactionId: e.transactionId
             },
             project_id: project_id,
-            current_idt_amount: e.assets[0].amount,
+            apt_token_id: apt_token_id,
+            current_idt_amount: current_idt_amount,
             pft_token_id: constants.pft_token_id,
             base_token_id: base_token_id,
             base_token_details: base_token_details,

--- a/src/lib/ergo/lineage.ts
+++ b/src/lib/ergo/lineage.ts
@@ -1,0 +1,179 @@
+import { explorer_uri } from "$lib/common/store";
+import { get } from "svelte/store";
+
+/**
+ * Resolving which box really is a project.
+ *
+ * A project has no verifiable on-chain identity in v1 and v2: it is identified by `tokens(0)` of
+ * the contract box - the APT - and that does not distinguish the real box from an imitation. The
+ * ErgoTree is the same for every v2 project, the APT circulates to buyers by design, and anyone
+ * holding one unit of it can build a box with the same script, the same id and registers of their
+ * choosing. Nothing in the contract stops them; see #176.
+ *
+ * What does distinguish the real box is where it came from. Every project starts as OUTPUTS(0) of
+ * the transaction that spends its mint box, and stays OUTPUTS(0) of every transaction that spends
+ * it afterwards, because the contract requires the replica to sit at index 0. So walking the chain
+ * of OUTPUTS(0) from the mint reaches exactly one box, and an imitation - which was created by
+ * some unrelated transaction, or at an index other than 0 - is never on that path.
+ *
+ * The walk also gets termination right for free. When a campaign closes, the transaction that
+ * spends the project box has a payment box at OUTPUTS(0), not a replica, so the chain ends there
+ * and the project is reported as finished. That includes the #174 case, where a clone was slipped
+ * in at index 2 of the terminating transaction: the clone is not on the path, so it is not the
+ * project, which is the answer we want.
+ *
+ * Cost is one explorer call per action the campaign has had. That is why {@link lineageCache}
+ * exists and why the walk is incremental: a resolved project only has to be walked forward from
+ * where it was left, not from the mint again.
+ */
+
+/** How far the walk will go before giving up, so a malformed chain cannot spin forever. */
+const MAX_CHAIN_LENGTH = 5000;
+
+export interface ExplorerBox {
+    boxId: string;
+    transactionId: string;
+    ergoTree: string;
+    value: number;
+    assets: { tokenId: string; amount: number }[];
+    additionalRegisters: Record<string, any>;
+    [key: string]: any;
+}
+
+export interface LineageResult {
+    /** The live project box, or null when the campaign has ended. */
+    box: ExplorerBox | null;
+    /** Why there is no box, when there is none. */
+    ended: boolean;
+    /** How many transactions were walked. Useful to see the cache working. */
+    steps: number;
+}
+
+interface CacheEntry {
+    /** Last box known to be on the chain. */
+    box: ExplorerBox;
+    /** True when that box was already spent into something that is not a project box. */
+    ended: boolean;
+}
+
+/**
+ * Last known position per project, so the next walk continues instead of restarting.
+ *
+ * Only ever holds boxes that were reached from the mint, so continuing from one cannot put the
+ * walk onto a chain it would not have reached anyway.
+ */
+const lineageCache = new Map<string, CacheEntry>();
+
+export function clearLineageCache(projectId?: string) {
+    if (projectId) lineageCache.delete(projectId);
+    else lineageCache.clear();
+}
+
+async function explorerJson(path: string): Promise<any | null> {
+    const response = await fetch(get(explorer_uri) + path, { method: "GET" });
+    if (!response.ok) return null;
+    return await response.json();
+}
+
+/** The box a token was minted into. For a project id that is the mint contract box. */
+async function mintBoxOf(tokenId: string): Promise<string | null> {
+    const token = await explorerJson("/api/v1/tokens/" + tokenId);
+    return token?.boxId ?? null;
+}
+
+async function boxById(boxId: string): Promise<any | null> {
+    return await explorerJson("/api/v1/boxes/" + boxId);
+}
+
+async function transactionById(txId: string): Promise<any | null> {
+    return await explorerJson("/api/v1/transactions/" + txId);
+}
+
+/**
+ * Whether `box` is the project carried forward, rather than a payment box that happens to sit at
+ * OUTPUTS(0) of the spending transaction.
+ *
+ * The test is that it still holds the project's APT at index 0, which is what the contract's
+ * `sameId` check enforces on every replication. A terminating transaction pays the owner at
+ * OUTPUTS(0) instead, and that box does not carry the APT.
+ */
+function carriesProject(box: ExplorerBox | null | undefined, projectId: string): boolean {
+    return !!box && Array.isArray(box.assets) && box.assets.length > 0 && box.assets[0].tokenId === projectId;
+}
+
+/**
+ * Walk forward from `box` for as long as OUTPUTS(0) of each spending transaction is still the
+ * project. Returns where it stopped.
+ */
+async function walkForward(projectId: string, from: ExplorerBox, alreadySteps: number): Promise<LineageResult> {
+    let current = from;
+    let steps = alreadySteps;
+
+    while (steps < MAX_CHAIN_LENGTH) {
+        const detail = await boxById(current.boxId);
+        if (!detail) {
+            // The explorer could not tell us about this box. Report what we have rather than
+            // inventing a conclusion: the caller can retry, and reporting "ended" here would
+            // wrongly hide a live campaign.
+            return { box: current, ended: false, steps };
+        }
+
+        const spentTx = detail.spentTransactionId;
+        if (!spentTx) {
+            lineageCache.set(projectId, { box: current, ended: false });
+            return { box: current, ended: false, steps };
+        }
+
+        const tx = await transactionById(spentTx);
+        const next = tx?.outputs?.[0];
+        steps += 1;
+
+        if (!carriesProject(next, projectId)) {
+            // The box was spent into something that is not the project: the campaign ended here.
+            lineageCache.set(projectId, { box: current, ended: true });
+            return { box: null, ended: true, steps };
+        }
+
+        current = next;
+    }
+
+    console.warn(`Lineage walk for ${projectId} hit the ${MAX_CHAIN_LENGTH} step limit`);
+    return { box: current, ended: false, steps };
+}
+
+/**
+ * The canonical box of a project, resolved from its mint rather than from its token id.
+ *
+ * Returns `box: null, ended: true` when the campaign has finished, and `box: null, ended: false`
+ * when the chain could not be resolved at all (no such token, or the explorer did not answer) -
+ * which the caller should treat as "unknown", not as "finished".
+ */
+export async function resolveCanonicalBox(projectId: string): Promise<LineageResult> {
+    const cached = lineageCache.get(projectId);
+    if (cached?.ended) return { box: null, ended: true, steps: 0 };
+    if (cached) return await walkForward(projectId, cached.box, 0);
+
+    const mintBoxId = await mintBoxOf(projectId);
+    if (!mintBoxId) return { box: null, ended: false, steps: 0 };
+
+    // The mint box is spent by creation Tx B, whose OUTPUTS(0) is the project box. mint_idt.es
+    // requires exactly that, so a project that exists at all starts here.
+    const mintBox = await boxById(mintBoxId);
+    if (!mintBox?.spentTransactionId) return { box: null, ended: false, steps: 0 };
+
+    const creationTx = await transactionById(mintBox.spentTransactionId);
+    const genesis = creationTx?.outputs?.[0];
+    if (!carriesProject(genesis, projectId)) return { box: null, ended: false, steps: 1 };
+
+    return await walkForward(projectId, genesis, 1);
+}
+
+/**
+ * Whether `boxId` is the canonical box of `projectId`.
+ *
+ * This is the question the UI actually needs answered when more than one box claims an id.
+ */
+export async function isCanonicalBox(projectId: string, boxId: string): Promise<boolean> {
+    const { box } = await resolveCanonicalBox(projectId);
+    return box?.boxId === boxId;
+}

--- a/src/lib/ergo/platform.ts
+++ b/src/lib/ergo/platform.ts
@@ -17,7 +17,11 @@ export class ErgoPlatform implements Platform {
     main_token = "ERG";
     icon = "";
     time_per_block = 2 * 60 * 1000;  // every 2 minutes
-    last_version: contract_version = "v2";
+    // What new campaigns are created with, and what the legacy badge measures every other version
+    // against. Moving this to v3 is what puts the singleton NFT on new campaigns (#176) and the
+    // rounded-up dev fee on their withdrawals (#177); campaigns already on chain keep replicating
+    // as whatever they were created as.
+    last_version: contract_version = "v3";
 
     constructor() {
         // Sync explorer URI from app to wallet library

--- a/src/lib/ergo/replica.ts
+++ b/src/lib/ergo/replica.ts
@@ -1,0 +1,110 @@
+import { OutputBuilder } from "@fleet-sdk/core";
+import { has_project_nft, type contract_version } from "./contract";
+import type { Project } from "$lib/common/project";
+
+/**
+ * Building the project box the same way every action does.
+ *
+ * The token layout changed in v3 - a singleton NFT at index 0, the APT moved to index 1 - and the
+ * contract reads identity and balances by index, so getting the order wrong produces a transaction
+ * the contract rejects. Rather than spell the layout out in each of the six actions that replicate
+ * the box, they all come through here.
+ */
+
+/**
+ * Add the tokens that identify the campaign, in the order the contract expects them.
+ *
+ * `aptAmount` is what the action leaves in the box: constant for a withdrawal, lower after a
+ * purchase, higher after a refund. The NFT is never anything but 1 - that is what makes it an NFT,
+ * and what lets a v3 box be recognised without walking its lineage.
+ */
+export function addIdentityTokens(
+    output: OutputBuilder,
+    project: Project,
+    aptAmount: bigint
+): OutputBuilder {
+    if (has_project_nft(project.version)) {
+        output.addTokens({ tokenId: project.project_id, amount: 1n });
+    }
+    output.addTokens({ tokenId: project.apt_token_id, amount: aptAmount });
+    return output;
+}
+
+/**
+ * The project box of a campaign being created, as Tx B has to build it.
+ *
+ * Extracted from submit.ts so that a contract test can run the real thing against the compiled
+ * mint contract: the whole question is what ends up at token index 0, and that is decided here.
+ *
+ * From v3 the identity is a singleton NFT minted in this very transaction. Its id is the id of
+ * INPUTS(0), and INPUTS(0) of Tx B is the mint box - a box that has just been spent and can never
+ * exist again, which is what makes the id unforgeable. It costs nothing extra: no separate
+ * transaction, no separate box. The builder places a minted token ahead of everything added
+ * afterwards, which is where mint_idt_v3.es and contract_v3.es read identity from.
+ */
+export function buildProjectOutput(opts: {
+    version: contract_version;
+    value: bigint;
+    ergoTree: string;
+    title: string;
+    /** APT first, then PFT. The NFT is not here: it is minted, and lands ahead of these. */
+    tokens: Array<{ tokenId: string; amount: bigint }>;
+    registers: Record<string, string>;
+}): OutputBuilder {
+    const output = new OutputBuilder(opts.value, opts.ergoTree);
+
+    if (has_project_nft(opts.version)) {
+        output.mintToken({
+            amount: 1n,
+            name: opts.title + " Project NFT",
+            decimals: 0,
+            description: "Identity of the " + opts.title + " campaign.",
+        });
+    }
+
+    output.addTokens(opts.tokens).setAdditionalRegisters(opts.registers as any);
+    return output;
+}
+
+/**
+ * How many tokens the project box of `version` will hold, given the ones passed explicitly.
+ * v3 adds the minted NFT on top, and the box has to be sized for it.
+ */
+export function project_token_count(version: contract_version, explicitTokens: number): number {
+    return explicitTokens + (has_project_nft(version) ? 1 : 0);
+}
+
+/**
+ * The dev fee the contract of `version` will require for extracting `extracted` base units.
+ *
+ * Two different rules, and the frontend has to match the box it is spending rather than the
+ * version the platform deploys today:
+ *
+ * - v1 and v2 compute `extracted * fee / 100` in integer arithmetic, which truncates. Withdrawing
+ *   19 units of a token campaign at a 5% fee gives 0, and the contract is satisfied - that is the
+ *   evasion reported in #177. It cannot be fixed for a campaign already on chain, because the
+ *   contract is immutable and would reject a larger fee than it computes.
+ * - v3 rounds up and requires the fee to be strictly positive whenever anything is extracted.
+ *
+ * Done in BigInt because the product can pass 2^53 on a token campaign with small units, and a
+ * fee that is off by one is not a rounding difference here: the contract compares it exactly, so
+ * the transaction simply fails.
+ */
+export function dev_fee_for(
+    extracted: number | bigint,
+    feePercentage: number,
+    version: contract_version
+): bigint {
+    const amount = BigInt(extracted);
+    const percentage = BigInt(feePercentage);
+    if (amount <= 0n) return 0n;
+
+    if (version === "v3") {
+        // Mirrors `(extractedBaseAmount * devFee + 99) / 100` in contract_v3.es.
+        return (amount * percentage + 99n) / 100n;
+    }
+
+    // Mirrors `extractedBaseAmount * devFee / 100` in contract_v2.es and earlier: integer
+    // division, so anything below one whole unit disappears.
+    return (amount * percentage) / 100n;
+}

--- a/src/routes/MyContributions.svelte
+++ b/src/routes/MyContributions.svelte
@@ -27,8 +27,8 @@
             return (
                 (tokens.has(project.pft_token_id) &&
                     (tokens.get(project.pft_token_id) ?? 0) > 0) ||
-                (tokens.has(project.project_id) &&
-                    (tokens.get(project.project_id) ?? 0) > 0)
+                (tokens.has(project.apt_token_id) &&
+                    (tokens.get(project.apt_token_id) ?? 0) > 0)
             );
         } catch (error) {
             console.error("Error checking project token:", error);

--- a/src/routes/ProjectCard.svelte
+++ b/src/routes/ProjectCard.svelte
@@ -3,6 +3,7 @@
     import { is_ended, min_raised, type Project } from "$lib/common/project";
     import { project_detail, connected, balance } from "$lib/common/store";
     import { badgeVariants } from "$lib/components/ui/badge";
+    import LegacyContractBadge from "$lib/components/LegacyContractBadge.svelte";
     import { Button } from "$lib/components/ui/button";
     import * as Card from "$lib/components/ui/card";
     import { ErgoPlatform } from "$lib/ergo/platform";
@@ -120,6 +121,7 @@
             >
                 {project.content.title}
             </Card.Title>
+            <LegacyContractBadge {project} compact />
             <div hidden>
                 <a
                     href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"

--- a/src/routes/ProjectDetails.svelte
+++ b/src/routes/ProjectDetails.svelte
@@ -21,6 +21,7 @@
     import { formatTransactionError } from "$lib/common/error-utils";
     import { ErgoPlatform } from "$lib/ergo/platform";
     import ShareModal from "$lib/components/ShareModal.svelte";
+    import LegacyContractBadge from "$lib/components/LegacyContractBadge.svelte";
     import {
         web_explorer_uri_tkn,
         web_explorer_uri_tx,
@@ -724,6 +725,9 @@
             if (updatedProject) {
                 project = {
                     ...project,
+                    // The box is replaced below, so the version has to come with it: leaving the
+                    // old one would let the badge describe a box it is not looking at.
+                    version: updatedProject.version,
                     sold_counter: updatedProject.sold_counter,
                     current_value: updatedProject.current_value,
                     refund_counter: updatedProject.refund_counter,
@@ -759,6 +763,9 @@
         >
             <div class="project-header">
                 <h1 class="project-title">{project.content.title}</h1>
+                <div class="project-badge">
+                    <LegacyContractBadge {project} />
+                </div>
                 <div class="project-badge" style="display: none;">
                     <a
                         href="https://github.com/StabilityNexus/BenefactionPlatform-Ergo/blob/main/contracts/bene_contract/contract_{project.version}.es"

--- a/src/routes/ProjectDetails.svelte
+++ b/src/routes/ProjectDetails.svelte
@@ -289,7 +289,8 @@
         const decimalDivisor = Math.pow(10, project.token_details.decimals);
         userProjectTokenBalance = rawProjectTokens / decimalDivisor;
 
-        const rawTemporalTokens = userTokens.get(project.project_id) || 0;
+        // The APT is what a contributor holds; from v3 on it is not the project id.
+        const rawTemporalTokens = userTokens.get(project.apt_token_id) || 0;
         userTemporalTokenBalance = rawTemporalTokens / decimalDivisor;
 
         let maxBaseTokenContribution;
@@ -709,8 +710,8 @@
         project_token_amount.set(formattedProjectTokens);
 
         var temporal_tokens =
-            (await platform.get_balance(project.project_id)).get(
-                project.project_id,
+            (await platform.get_balance(project.apt_token_id)).get(
+                project.apt_token_id,
             ) ?? 0;
         const normalizedTemporalTokens =
             temporal_tokens / Math.pow(10, project.token_details.decimals);

--- a/tests/contracts/bene_v3_helpers.ts
+++ b/tests/contracts/bene_v3_helpers.ts
@@ -1,0 +1,152 @@
+import { MockChain, type KeyedMockChainParty, type NonKeyedMockChainParty } from "@fleet-sdk/mock-chain";
+import { compile } from "@fleet-sdk/compiler";
+import { ErgoAddress } from "@fleet-sdk/core";
+import { blake2b256 } from "@fleet-sdk/crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { createR8Structure } from "$lib/common/project";
+import { SBool, SLong, SPair } from "@fleet-sdk/serializer";
+
+export function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("hex");
+}
+
+const contractsDir = path.resolve(__dirname, "../../contracts/bene_contract");
+export const BENE_CONTRACT_V3 = fs.readFileSync(
+  path.join(contractsDir, "contract_v3.es"),
+  "utf-8"
+);
+
+/**
+ * `{ sigmaProp(false) }` - the script the project NFT is retired into when a campaign ends.
+ * The contract carries its proposition bytes as a literal; if this ever stops matching, the
+ * terminal-box tests fail loudly rather than silently accepting any box.
+ */
+export const TERMINAL_CONTRACT = compile(`{ sigmaProp(false) }`);
+
+export const TOTAL_PFT_TOKENS = 100_000n;
+export const ERG_BASE_TOKEN = "";
+export const ERG_BASE_TOKEN_NAME = "ERG";
+export const ERG_FUNDING_GOAL = 100_000_000_000n;
+
+/** A token-denominated campaign, which is where the fee truncation of #177 is reachable. */
+export const USD_BASE_TOKEN = "03faf2cb329f2e90d6d23b58d91bbb6c046aa143261cc21f52fbe2824bfcbf04";
+export const USD_BASE_TOKEN_NAME = "SigmaUSD";
+export const USD_FUNDING_GOAL = 10_000_000n;
+
+export interface BeneV3TestContext {
+  mockChain: MockChain;
+  constants: any;
+  projectOwner: KeyedMockChainParty;
+  buyer: KeyedMockChainParty;
+  beneContract: NonKeyedMockChainParty;
+  beneErgoTree: ReturnType<typeof compile>;
+  devFeeContract: ReturnType<typeof compile>;
+  /** Singleton NFT, tokens(0), amount 1. This is the project identity in v3. */
+  projectNftId: string;
+  /** APT, tokens(1). Circulates to buyers; no longer identifies anything. */
+  aptTokenId: string;
+  pftTokenId: string;
+  baseTokenId: string;
+  isErgMode: boolean;
+  fundingGoal: bigint;
+  exchangeRate: bigint;
+  totalPFTokens: bigint;
+  minimumTokensSold: bigint;
+  deadlineBlock: number;
+  deadlineTimestamp: bigint;
+  devFeePercentage: number;
+}
+
+/**
+ * Mirrors setupBeneTestContext for v3. The one structural difference is the token layout: the
+ * project box carries a singleton NFT at tokens(0) and the APT at tokens(1), where v2 had the
+ * APT at tokens(0) doing both jobs.
+ */
+export function setupBeneV3TestContext(
+  baseTokenId: string,
+  baseTokenName: string,
+  ownerAddress: ErgoAddress | null = null
+): BeneV3TestContext {
+  const mockChain = new MockChain({ height: 800_000 });
+
+  const projectOwner = mockChain.newParty("ProjectOwner");
+  const buyer = mockChain.newParty("Buyer");
+
+  const isErgMode = baseTokenId === "";
+  const fundingGoal = isErgMode ? ERG_FUNDING_GOAL : USD_FUNDING_GOAL;
+  const totalPFTokens = TOTAL_PFT_TOKENS;
+  const exchangeRate = fundingGoal / totalPFTokens;
+  const minimumTokensSold = totalPFTokens / 2n;
+  const deadlineBlock = 800_200;
+  const deadlineTimestamp = BigInt(mockChain.timestamp) + (BigInt(deadlineBlock - 800_000) * 120_000n);
+  const devFeePercentage = 5;
+
+  buyer.addBalance({ nanoergs: 50_000_000_000n });
+
+  if (!isErgMode) {
+    buyer.addUTxOs({
+      value: 10_000_000_000n,
+      ergoTree: buyer.address.ergoTree,
+      assets: [{ tokenId: baseTokenId, amount: fundingGoal * 10n }],
+      creationHeight: mockChain.height - 50,
+      additionalRegisters: {},
+    });
+  }
+
+  // Three distinct ids now: the NFT identifies, the APT circulates, the PFT is the reward.
+  const projectNftId = "00ff00ff1234567890abcdef1234567890abcdef1234567890abcdef00ff00ff";
+  const aptTokenId = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+  const pftTokenId = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+  if (ownerAddress === null) {
+    ownerAddress = ErgoAddress.fromBase58(projectOwner.address.toString());
+  }
+
+  const devFeeContract = compile(`{ sigmaProp(true) }`);
+  const devFeeContractHash = uint8ArrayToHex(blake2b256(devFeeContract.bytes));
+
+  const constants = createR8Structure({
+    owner: ownerAddress.ergoTree,
+    dev_hash: devFeeContractHash,
+    dev_fee: devFeePercentage,
+    pft_token_id: pftTokenId,
+    base_token_id: baseTokenId,
+  });
+
+  const beneErgoTree = compile(BENE_CONTRACT_V3);
+  const beneContract = mockChain.addParty(beneErgoTree.toHex(), `BeneContractV3-${baseTokenName}`);
+
+  return {
+    mockChain,
+    constants,
+    projectOwner,
+    buyer,
+    beneContract,
+    beneErgoTree,
+    devFeeContract,
+    projectNftId,
+    aptTokenId,
+    pftTokenId,
+    baseTokenId,
+    isErgMode,
+    fundingGoal,
+    exchangeRate,
+    totalPFTokens,
+    minimumTokensSold,
+    deadlineBlock,
+    deadlineTimestamp,
+    devFeePercentage,
+  };
+}
+
+export function createR4(ctx: BeneV3TestContext, useTimestamp: boolean = false) {
+  return useTimestamp
+    ? SPair(SBool(true), SLong(ctx.deadlineTimestamp)).toHex()
+    : SPair(SBool(false), SLong(BigInt(ctx.deadlineBlock))).toHex();
+}
+
+/** The dev fee v3 charges: rounded up, so it can no longer be truncated to nothing (#177). */
+export function devFeeOf(extracted: bigint, percentage: number): bigint {
+  return (extracted * BigInt(percentage) + 99n) / 100n;
+}

--- a/tests/contracts/v3_creation.test.ts
+++ b/tests/contracts/v3_creation.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MockChain, type KeyedMockChainParty, type NonKeyedMockChainParty } from "@fleet-sdk/mock-chain";
+import {
+  OutputBuilder,
+  TransactionBuilder,
+  RECOMMENDED_MIN_FEE_VALUE,
+  SAFE_MIN_BOX_VALUE,
+} from "@fleet-sdk/core";
+import { compile } from "@fleet-sdk/compiler";
+import { blake2b256 } from "@fleet-sdk/crypto";
+import { SBool, SByte, SColl, SLong, SPair } from "@fleet-sdk/serializer";
+import { stringToBytes } from "@scure/base";
+import * as fs from "fs";
+import * as path from "path";
+import { BENE_CONTRACT_V3, uint8ArrayToHex } from "./bene_v3_helpers";
+import { buildProjectOutput } from "$lib/ergo/replica";
+
+/**
+ * Creating a v3 campaign, against the compiled mint contract.
+ *
+ * The frontend builds this as two chained transactions: Tx A mints the APT into a box locked by
+ * mint_idt_v3.es, and Tx B spends that box into the project box. What is new in v3 is that Tx B
+ * also mints the project NFT - at no extra cost, because a token minted on Ergo takes the id of
+ * INPUTS(0), and INPUTS(0) of Tx B is the mint box, which has just been spent and can never be
+ * reproduced.
+ *
+ * The reason this is a contract test and not a unit test is that the whole thing turns on the
+ * order of tokens in the output box, and on which input is first. Neither can be established by
+ * reading the builder: they are decided when the transaction is built, and the only authority on
+ * whether the result is acceptable is the compiled contract.
+ */
+
+const MINT_CONTRACT_V3 = fs.readFileSync(
+  path.resolve(__dirname, "../../contracts/mint_contract/mint_idt_v3.es"),
+  "utf-8"
+);
+
+const TOTAL_PFT = 100_000n;
+const APT_AMOUNT = TOTAL_PFT + 1n;
+const DEADLINE_BLOCK = 900_000n;
+
+describe("Bene v3 - campaign creation", () => {
+  let chain: MockChain;
+  let owner: KeyedMockChainParty;
+  let mintParty: NonKeyedMockChainParty;
+  let beneErgoTree: ReturnType<typeof compile>;
+  let pftTokenId: string;
+
+  beforeEach(() => {
+    chain = new MockChain({ height: 800_000 });
+    owner = chain.newParty("Owner");
+
+    beneErgoTree = compile(BENE_CONTRACT_V3);
+    const contractBytesHash = uint8ArrayToHex(blake2b256(beneErgoTree.bytes));
+    const mintTree = compile(MINT_CONTRACT_V3.replace(/`\+contract_bytes_hash\+`/g, contractBytesHash));
+    mintParty = chain.addParty(mintTree.toHex(), "MintV3");
+
+    // The PFT is minted by the owner before any of this; here it just has to exist.
+    pftTokenId = "f".repeat(64);
+    owner.addBalance({ nanoergs: 100_000_000_000n });
+    owner.addUTxOs({
+      value: 10_000_000_000n,
+      ergoTree: owner.address.ergoTree,
+      assets: [{ tokenId: pftTokenId, amount: TOTAL_PFT }],
+      creationHeight: chain.height - 50,
+      additionalRegisters: {},
+    });
+  });
+
+  /** Tx A: mint the APT into the mint box. Returns the APT id and the mint box. */
+  function mintApt() {
+    const issuanceBox = owner.utxos.toArray()[0];
+    const txA = new TransactionBuilder(chain.height)
+      .from([issuanceBox, ...owner.utxos.toArray().filter((b) => b.boxId !== issuanceBox.boxId)])
+      .to(
+        new OutputBuilder(SAFE_MIN_BOX_VALUE, mintParty.address).mintToken({
+          amount: APT_AMOUNT,
+          name: "Test APT",
+          decimals: 0,
+          description: "Temporal-funding token",
+        })
+      )
+      .sendChangeTo(owner.address)
+      .payFee(RECOMMENDED_MIN_FEE_VALUE)
+      .build();
+
+    expect(chain.execute(txA, { signers: [owner], throw: false })).toBe(true);
+
+    const mintBox = mintParty.utxos.toArray()[0];
+    // On Ergo the minted id is the id of INPUTS(0) of the issuing transaction.
+    return { aptTokenId: issuanceBox.boxId, mintBox };
+  }
+
+  function registers() {
+    return {
+      R4: SPair(SBool(false), SLong(DEADLINE_BLOCK)).toHex(),
+      R5: SLong(TOTAL_PFT / 2n).toHex(),
+      R6: SColl(SLong, [0n, 0n, 0n]).toHex(),
+      R7: SLong(1_000_000n).toHex(),
+      R8: SColl(SColl(SByte), [
+        owner.address.ergoTree,
+        uint8ArrayToHex(blake2b256(compile(`{ sigmaProp(true) }`).bytes)),
+        "05",
+        pftTokenId,
+        "",
+      ]).toHex(),
+      R9: SColl(SByte, stringToBytes("utf8", JSON.stringify({ title: "T", description: "D" }))).toHex(),
+    };
+  }
+
+  /**
+   * Tx B, as the frontend builds it: the mint box first, the project box at OUTPUTS(0), the NFT
+   * minted here so that its id is the mint box's.
+   */
+  function buildCreation(opts: {
+    nftAmount?: bigint;
+    mintNft?: boolean;
+    aptTokenId: string;
+    mintBox: any;
+  }) {
+    const { aptTokenId, mintBox } = opts;
+    const inputs = [mintBox, ...owner.utxos.toArray()];
+
+    // The production builder, so that this checks what submit.ts actually sends.
+    const tokens = [
+      { tokenId: aptTokenId, amount: APT_AMOUNT },
+      { tokenId: pftTokenId, amount: TOTAL_PFT },
+    ];
+    let projectOutput;
+    if (opts.mintNft === false) {
+      // What the v2 flow builds - the same call with a version that mints nothing.
+      projectOutput = buildProjectOutput({
+        version: "v2",
+        value: SAFE_MIN_BOX_VALUE * 2n,
+        ergoTree: beneErgoTree.toHex(),
+        title: "T",
+        tokens,
+        registers: registers(),
+      });
+    } else if (opts.nftAmount !== undefined) {
+      // Not reachable through buildProjectOutput, which always mints exactly one - which is the
+      // point. Built by hand so the contract's own check is exercised.
+      projectOutput = new OutputBuilder(SAFE_MIN_BOX_VALUE * 2n, beneErgoTree)
+        .mintToken({ amount: opts.nftAmount, name: "T", decimals: 0, description: "d" })
+        .addTokens(tokens)
+        .setAdditionalRegisters(registers() as any);
+    } else {
+      projectOutput = buildProjectOutput({
+        version: "v3",
+        value: SAFE_MIN_BOX_VALUE * 2n,
+        ergoTree: beneErgoTree.toHex(),
+        title: "T",
+        tokens,
+        registers: registers(),
+      });
+    }
+
+    return new TransactionBuilder(chain.height)
+      .from(inputs)
+      .to(projectOutput)
+      .sendChangeTo(owner.address)
+      .payFee(RECOMMENDED_MIN_FEE_VALUE)
+      .build();
+  }
+
+  it("creates the project box, with the NFT minted in the same transaction", () => {
+    const { aptTokenId, mintBox } = mintApt();
+
+    const txB = buildCreation({ aptTokenId, mintBox });
+
+    expect(chain.execute(txB, { signers: [owner], throw: false })).toBe(true);
+
+    const projectBox = txB.outputs[0];
+
+    // What the contract reads by index, in the order it reads it.
+    expect(projectBox.assets).toHaveLength(3);
+    expect(projectBox.assets[0].amount).toBe(1n);
+    expect(projectBox.assets[0].tokenId).toBe(mintBox.boxId);
+    expect(projectBox.assets[1].tokenId).toBe(aptTokenId);
+    expect(projectBox.assets[1].amount).toBe(APT_AMOUNT);
+    expect(projectBox.assets[2].tokenId).toBe(pftTokenId);
+  });
+
+  it("refuses a project box with no NFT at tokens(0)", () => {
+    // This is exactly what the v2 flow builds: APT first, PFT second, nothing minted here.
+    const { aptTokenId, mintBox } = mintApt();
+
+    const txB = buildCreation({ aptTokenId, mintBox, mintNft: false });
+
+    expect(chain.execute(txB, { signers: [owner], throw: false })).toBe(false);
+  });
+
+  it("refuses an identity token that is not a singleton", () => {
+    const { aptTokenId, mintBox } = mintApt();
+
+    const txB = buildCreation({ aptTokenId, mintBox, nftAmount: 2n });
+
+    expect(chain.execute(txB, { signers: [owner], throw: false })).toBe(false);
+  });
+
+  it("refuses a transaction that does not spend the mint box first", () => {
+    // The minted id is the id of INPUTS(0). If the mint box were anywhere else, the id would come
+    // from one of the owner's own boxes - which the owner chooses, and could arrange to reproduce.
+    //
+    // Fleet will not build this: asked for the funding box first, its selector still puts the
+    // token-bearing box at index 0, which is a useful property of the library but leaves the
+    // contract's own guard untested. So the order is swapped after the fact.
+    const { aptTokenId, mintBox } = mintApt();
+
+    const txB = buildCreation({ aptTokenId, mintBox });
+    expect(txB.inputs[0].boxId).toBe(mintBox.boxId);
+    expect(txB.inputs.length).toBeGreaterThan(1);
+    [txB.inputs[0], txB.inputs[1]] = [txB.inputs[1], txB.inputs[0]];
+
+    expect(chain.execute(txB, { signers: [owner], throw: false })).toBe(false);
+  });
+});

--- a/tests/contracts/v3_invariants.test.ts
+++ b/tests/contracts/v3_invariants.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Box } from "@fleet-sdk/core";
+import { OutputBuilder, TransactionBuilder, RECOMMENDED_MIN_FEE_VALUE, SAFE_MIN_BOX_VALUE } from "@fleet-sdk/core";
+import { SByte, SColl, SLong } from "@fleet-sdk/serializer";
+import { stringToBytes } from "@scure/base";
+import { createR8Structure } from "$lib/common/project";
+import {
+  setupBeneV3TestContext,
+  createR4,
+  devFeeOf,
+  uint8ArrayToHex,
+  TERMINAL_CONTRACT,
+  ERG_BASE_TOKEN,
+  ERG_BASE_TOKEN_NAME,
+  USD_BASE_TOKEN,
+  USD_BASE_TOKEN_NAME,
+  type BeneV3TestContext,
+} from "./bene_v3_helpers";
+import { blake2b256 } from "@fleet-sdk/crypto";
+
+const METADATA = SColl(SByte, stringToBytes("utf8", "{}")).toHex();
+
+// The two invariants v3 adds, and the three ways v2 let them be broken:
+//
+//   #174  a copy of the contract at any index other than 0 escaped every replication guard;
+//   #176  identity was the APT, which circulates, so anybody holding one could impersonate a project;
+//   #177  isWithdrawUnsoldTokens could terminate, which made mantainValue vacuous and let the owner
+//         take the balance without paying the fee; and the fee itself truncated to zero on small
+//         enough withdrawals of a token campaign.
+describe("Bene Contract v3 - replication and identity invariants", () => {
+  let ctx: BeneV3TestContext;
+  let projectBox: Box;
+  let soldTokens: bigint;
+  let collectedFunds: bigint;
+  let remainingAPT: bigint;
+  let unsoldPFT: bigint;
+
+  /** A campaign past its minimum, with PFT still in the box. */
+  function fundedProject(withPFT: bigint) {
+    soldTokens = ctx.minimumTokensSold;
+    remainingAPT = 1n + ctx.totalPFTokens - soldTokens;
+    collectedFunds = SAFE_MIN_BOX_VALUE + soldTokens * ctx.exchangeRate;
+    unsoldPFT = withPFT;
+
+    const assets: { tokenId: string; amount: bigint }[] = [
+      { tokenId: ctx.projectNftId, amount: 1n },
+      { tokenId: ctx.aptTokenId, amount: remainingAPT },
+    ];
+    if (withPFT > 0n) assets.push({ tokenId: ctx.pftTokenId, amount: withPFT });
+
+    ctx.beneContract.addUTxOs({
+      value: collectedFunds,
+      ergoTree: ctx.beneErgoTree.toHex(),
+      assets,
+      creationHeight: ctx.mockChain.height - 100,
+      additionalRegisters: {
+        R4: createR4(ctx),
+        R5: SLong(ctx.minimumTokensSold).toHex(),
+        // sold, refunded, exchanged. Everything sold has been exchanged for PFT already,
+        // which is the ordinary end state of a successful campaign.
+        R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+        R7: SLong(ctx.exchangeRate).toHex(),
+        R8: ctx.constants.toHex(),
+        R9: METADATA,
+      },
+    });
+
+    projectBox = ctx.beneContract.utxos.toArray()[0];
+  }
+
+  /** The box the NFT has to end up in when the campaign closes. */
+  function terminalBox(ctx: BeneV3TestContext) {
+    return new OutputBuilder(SAFE_MIN_BOX_VALUE, TERMINAL_CONTRACT)
+      .addTokens([{ tokenId: ctx.projectNftId, amount: 1n }]);
+  }
+
+  describe("ERG campaign", () => {
+    beforeEach(() => {
+      ctx = setupBeneV3TestContext(ERG_BASE_TOKEN, ERG_BASE_TOKEN_NAME);
+      ctx.projectOwner.addBalance({ nanoergs: 10_000_000_000n });
+    });
+
+    // ===== #174: a clone anywhere in the outputs kills the transaction =====
+
+    it("should allow a legitimate full withdrawal that retires the NFT", () => {
+      fundedProject(0n);
+      const spender = ctx.buyer;
+      const devFeeAmount = devFeeOf(collectedFunds, ctx.devFeePercentage);
+      const projectAmount = collectedFunds - devFeeAmount;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(projectAmount, ctx.projectOwner.address),
+          new OutputBuilder(devFeeAmount, ctx.devFeeContract),
+          terminalBox(ctx),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(true);
+    });
+
+    it("should not allow a withdrawal to recreate the contract outside OUTPUTS(0)", () => {
+      // The transaction #174 walks through, rebuilt against v3. The owner and the dev fee are
+      // paid exactly what the contract asks; the theft is in what is left behind.
+      fundedProject(0n);
+      const spender = ctx.buyer;
+      const devFeeAmount = devFeeOf(collectedFunds, ctx.devFeePercentage);
+      const projectAmount = collectedFunds - devFeeAmount;
+
+      const rogueConstants = createR8Structure({
+        owner: spender.address.ergoTree,
+        dev_hash: uint8ArrayToHex(blake2b256(ctx.devFeeContract.bytes)),
+        dev_fee: ctx.devFeePercentage,
+        pft_token_id: ctx.pftTokenId,
+        base_token_id: ctx.baseTokenId,
+      });
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(projectAmount, ctx.projectOwner.address),
+          new OutputBuilder(devFeeAmount, ctx.devFeeContract),
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.beneErgoTree)
+            .addTokens([
+              { tokenId: ctx.projectNftId, amount: 1n },
+              { tokenId: ctx.aptTokenId, amount: remainingAPT },
+            ])
+            .setAdditionalRegisters({
+              R4: createR4(ctx),
+              R5: SLong(0n).toHex(),
+              R6: SColl(SLong, [0n, 0n, ctx.totalPFTokens]).toHex(),
+              R7: SLong(1n).toHex(),
+              R8: rogueConstants.toHex(),
+              R9: METADATA,
+            }),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(false);
+    });
+
+    it("should not allow a second copy of the contract alongside a valid replica", () => {
+      // The general form: even when OUTPUTS(0) is a perfectly valid replica, a second box with
+      // the same script may not ride along. In v2 this made isReplicationBoxPresent false and
+      // emptied every guard; here replicas.size <= 1 rejects it outright.
+      fundedProject(0n);
+      const spender = ctx.buyer;
+      const partial = 1_000_000_000n;
+      const devFeeAmount = devFeeOf(partial, ctx.devFeePercentage);
+      const projectAmount = partial - devFeeAmount;
+
+      const replica = new OutputBuilder(collectedFunds - partial, ctx.beneErgoTree)
+        .addTokens([
+          { tokenId: ctx.projectNftId, amount: 1n },
+          { tokenId: ctx.aptTokenId, amount: remainingAPT },
+        ])
+        .setAdditionalRegisters({
+          R4: createR4(ctx),
+          R5: SLong(ctx.minimumTokensSold).toHex(),
+          R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+          R7: SLong(ctx.exchangeRate).toHex(),
+          R8: ctx.constants.toHex(),
+          R9: METADATA,
+        });
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          replica,
+          new OutputBuilder(projectAmount, ctx.projectOwner.address),
+          new OutputBuilder(devFeeAmount, ctx.devFeeContract),
+          // A second box with the contract script, carrying nothing of consequence.
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.beneErgoTree).setAdditionalRegisters({
+            R4: createR4(ctx),
+            R5: SLong(0n).toHex(),
+            R6: SColl(SLong, [0n, 0n, 0n]).toHex(),
+            R7: SLong(1n).toHex(),
+            R8: ctx.constants.toHex(),
+            R9: METADATA,
+          }),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(false);
+    });
+
+    // ===== #176: the identity cannot leave, be duplicated or be dropped =====
+
+    it("should not allow terminating without retiring the NFT", () => {
+      // Everything paid correctly, but the NFT goes to the spender's change instead of a box
+      // nobody can spend. That is what lets a closed campaign be resurrected later.
+      fundedProject(0n);
+      const spender = ctx.buyer;
+      const devFeeAmount = devFeeOf(collectedFunds, ctx.devFeePercentage);
+      const projectAmount = collectedFunds - devFeeAmount;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(projectAmount, ctx.projectOwner.address),
+          new OutputBuilder(devFeeAmount, ctx.devFeeContract),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(false);
+    });
+
+    it("should not allow a replica that drops the NFT", () => {
+      fundedProject(0n);
+      const spender = ctx.buyer;
+      const partial = 1_000_000_000n;
+      const devFeeAmount = devFeeOf(partial, ctx.devFeePercentage);
+      const projectAmount = partial - devFeeAmount;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(collectedFunds - partial, ctx.beneErgoTree)
+            // NFT missing: only the APT is carried over.
+            .addTokens([{ tokenId: ctx.aptTokenId, amount: remainingAPT }])
+            .setAdditionalRegisters({
+              R4: createR4(ctx),
+              R5: SLong(ctx.minimumTokensSold).toHex(),
+              R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+              R7: SLong(ctx.exchangeRate).toHex(),
+              R8: ctx.constants.toHex(),
+              R9: METADATA,
+            }),
+          new OutputBuilder(projectAmount, ctx.projectOwner.address),
+          new OutputBuilder(devFeeAmount, ctx.devFeeContract),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(false);
+    });
+
+    // ===== #177 path 1: isWithdrawUnsoldTokens can no longer terminate =====
+
+    it("should not let the owner terminate through isWithdrawUnsoldTokens and keep the funds", () => {
+      // The exact scenario of #177: a campaign that did not sell its whole emission, whose APT
+      // have all been exchanged. In v2 the owner signs, takes the unsold PFT and the whole ERG
+      // balance in one transaction, and the platform is paid nothing.
+      fundedProject(20_000n);
+      const owner = ctx.projectOwner;
+
+      // The NFT is retired properly, so the identity invariant is satisfied and the only thing
+      // standing between the owner and the money is isWithdrawUnsoldTokens having to replicate.
+      // Without that, mantainValue is vacuous and nothing constrains the balance.
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...owner.utxos.toArray()])
+        .to([
+          // Everything the box held, straight to the owner. No replica, no dev fee.
+          new OutputBuilder(collectedFunds, owner.address)
+            .addTokens([
+              { tokenId: ctx.aptTokenId, amount: remainingAPT },
+              { tokenId: ctx.pftTokenId, amount: unsoldPFT },
+            ]),
+          terminalBox(ctx),
+        ])
+        .sendChangeTo(owner.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [owner], throw: false })).toBe(false);
+    });
+
+    it("should still allow the owner to withdraw unsold tokens while replicating", () => {
+      // The positive control for the change above: the same withdrawal, replicating as it must.
+      fundedProject(20_000n);
+      const owner = ctx.projectOwner;
+      const withdrawn = 5_000n;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...owner.utxos.toArray()])
+        .to([
+          new OutputBuilder(collectedFunds, ctx.beneErgoTree)
+            .addTokens([
+              { tokenId: ctx.projectNftId, amount: 1n },
+              { tokenId: ctx.aptTokenId, amount: remainingAPT },
+              { tokenId: ctx.pftTokenId, amount: unsoldPFT - withdrawn },
+            ])
+            .setAdditionalRegisters({
+              R4: createR4(ctx),
+              R5: SLong(ctx.minimumTokensSold).toHex(),
+              R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+              R7: SLong(ctx.exchangeRate).toHex(),
+              R8: ctx.constants.toHex(),
+              R9: METADATA,
+            }),
+        ])
+        .sendChangeTo(owner.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [owner], throw: false })).toBe(true);
+    });
+  });
+
+  // ===== #177 path 2: the fee cannot be truncated away =====
+
+  describe("token campaign", () => {
+    beforeEach(() => {
+      ctx = setupBeneV3TestContext(USD_BASE_TOKEN, USD_BASE_TOKEN_NAME);
+      ctx.projectOwner.addBalance({ nanoergs: 10_000_000_000n });
+    });
+
+    function fundedTokenProject() {
+      soldTokens = ctx.minimumTokensSold;
+      remainingAPT = 1n + ctx.totalPFTokens - soldTokens;
+      collectedFunds = soldTokens * ctx.exchangeRate;
+
+      ctx.beneContract.addUTxOs({
+        value: SAFE_MIN_BOX_VALUE,
+        ergoTree: ctx.beneErgoTree.toHex(),
+        assets: [
+          { tokenId: ctx.projectNftId, amount: 1n },
+          { tokenId: ctx.aptTokenId, amount: remainingAPT },
+          { tokenId: ctx.baseTokenId, amount: collectedFunds },
+        ],
+        creationHeight: ctx.mockChain.height - 100,
+        additionalRegisters: {
+          R4: createR4(ctx),
+          R5: SLong(ctx.minimumTokensSold).toHex(),
+          R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+          R7: SLong(ctx.exchangeRate).toHex(),
+          R8: ctx.constants.toHex(),
+          R9: METADATA,
+        },
+      });
+
+      projectBox = ctx.beneContract.utxos.toArray()[0];
+    }
+
+    it("should not allow a withdrawal small enough to round the dev fee to zero", () => {
+      // 19 units at 5%: v2 computed 19 * 5 / 100 = 0 and the dev fee box was accepted with no
+      // tokens at all, so the whole balance could be taken out 19 units at a time for free.
+      fundedTokenProject();
+      const spender = ctx.buyer;
+      const extracted = 19n;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.beneErgoTree)
+            .addTokens([
+              { tokenId: ctx.projectNftId, amount: 1n },
+              { tokenId: ctx.aptTokenId, amount: remainingAPT },
+              { tokenId: ctx.baseTokenId, amount: collectedFunds - extracted },
+            ])
+            .setAdditionalRegisters({
+              R4: createR4(ctx),
+              R5: SLong(ctx.minimumTokensSold).toHex(),
+              R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+              R7: SLong(ctx.exchangeRate).toHex(),
+              R8: ctx.constants.toHex(),
+              R9: METADATA,
+            }),
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.projectOwner.address)
+            .addTokens([{ tokenId: ctx.baseTokenId, amount: extracted }]),
+          // The dev fee box v2 accepted: no base tokens whatsoever, because 0 == 0.
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.devFeeContract),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(false);
+    });
+
+    it("should allow the same small withdrawal once the rounded-up fee is paid", () => {
+      // The positive control: 19 units extracted, 1 unit of fee - which is what rounding up asks
+      // for - and the transaction goes through.
+      fundedTokenProject();
+      const spender = ctx.buyer;
+      const extracted = 19n;
+      const devFeeAmount = devFeeOf(extracted, ctx.devFeePercentage);
+      const projectAmount = extracted - devFeeAmount;
+
+      const transaction = new TransactionBuilder(ctx.mockChain.height)
+        .from([projectBox, ...spender.utxos.toArray()])
+        .to([
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.beneErgoTree)
+            .addTokens([
+              { tokenId: ctx.projectNftId, amount: 1n },
+              { tokenId: ctx.aptTokenId, amount: remainingAPT },
+              { tokenId: ctx.baseTokenId, amount: collectedFunds - extracted },
+            ])
+            .setAdditionalRegisters({
+              R4: createR4(ctx),
+              R5: SLong(ctx.minimumTokensSold).toHex(),
+              R6: SColl(SLong, [soldTokens, 0n, soldTokens]).toHex(),
+              R7: SLong(ctx.exchangeRate).toHex(),
+              R8: ctx.constants.toHex(),
+              R9: METADATA,
+            }),
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.projectOwner.address)
+            .addTokens([{ tokenId: ctx.baseTokenId, amount: projectAmount }]),
+          new OutputBuilder(SAFE_MIN_BOX_VALUE, ctx.devFeeContract)
+            .addTokens([{ tokenId: ctx.baseTokenId, amount: devFeeAmount }]),
+        ])
+        .sendChangeTo(spender.address)
+        .payFee(RECOMMENDED_MIN_FEE_VALUE)
+        .build();
+
+      expect(ctx.mockChain.execute(transaction, { signers: [spender], throw: false })).toBe(true);
+    });
+  });
+});

--- a/tests/frontend/dev_fee.test.ts
+++ b/tests/frontend/dev_fee.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { dev_fee_for } from "$lib/ergo/replica";
+import { devFeeOf } from "../contracts/bene_v3_helpers";
+
+/**
+ * The fee the frontend offers has to be exactly the fee the contract of that box computes. Too
+ * low and the contract rejects the transaction; too high and the owner pays more than they owe.
+ * v3 rounds up (#177), everything before it truncates and cannot be changed, because those
+ * contracts are already on chain.
+ */
+
+const FEE = 5;
+
+describe("dev_fee_for on v3", () => {
+    it("rounds up rather than truncating", () => {
+        // 19 * 5% = 0.95. v2 gives 0, which is the evasion #177 reports.
+        expect(dev_fee_for(19, FEE, "v3")).toBe(1n);
+        expect(dev_fee_for(1, FEE, "v3")).toBe(1n);
+        expect(dev_fee_for(21, FEE, "v3")).toBe(2n);
+    });
+
+    it("is exact when the percentage divides evenly", () => {
+        expect(dev_fee_for(100, FEE, "v3")).toBe(5n);
+        expect(dev_fee_for(20, FEE, "v3")).toBe(1n);
+    });
+
+    it("charges nothing when nothing is extracted", () => {
+        expect(dev_fee_for(0, FEE, "v3")).toBe(0n);
+    });
+
+    it("matches the contract's own arithmetic across a range", () => {
+        // contract_v3.es: (extractedBaseAmount * devFee + 99) / 100, integer division.
+        for (let extracted = 0; extracted <= 500; extracted++) {
+            const expected = (BigInt(extracted) * BigInt(FEE) + 99n) / 100n;
+            expect(dev_fee_for(extracted, FEE, "v3")).toBe(extracted === 0 ? 0n : expected);
+        }
+    });
+});
+
+describe("dev_fee_for on the versions already on chain", () => {
+    it("truncates on v2, because the deployed contract does", () => {
+        // Not a bug being reproduced for its own sake: offering 1 here would build a transaction
+        // the v2 contract rejects, since it computes 0 and requires the output to match.
+        expect(dev_fee_for(19, FEE, "v2")).toBe(0n);
+        expect(dev_fee_for(20, FEE, "v2")).toBe(1n);
+        expect(dev_fee_for(39, FEE, "v2")).toBe(1n);
+    });
+
+    it("truncates on v1 too", () => {
+        expect(dev_fee_for(19, FEE, "v1_1")).toBe(0n);
+        expect(dev_fee_for(19, FEE, "v1_0")).toBe(0n);
+    });
+
+    it("matches contract_v2's arithmetic across a range", () => {
+        for (let extracted = 0; extracted <= 500; extracted++) {
+            expect(dev_fee_for(extracted, FEE, "v2")).toBe((BigInt(extracted) * BigInt(FEE)) / 100n);
+        }
+    });
+});
+
+describe("dev_fee_for arithmetic", () => {
+    it("stays exact past the range a double can represent", () => {
+        // A token campaign with 9 decimals raising ~10M units of base token puts the product over
+        // 2^53, where floating point silently stops counting by ones.
+        const extracted = 9_007_199_254_740_993n; // 2^53 + 1
+        expect(dev_fee_for(extracted, FEE, "v3")).toBe((extracted * 5n + 99n) / 100n);
+        expect(dev_fee_for(extracted, FEE, "v2")).toBe((extracted * 5n) / 100n);
+    });
+
+    it("treats a negative extraction as nothing to charge for", () => {
+        // Not reachable from the UI, but without the guard the rounding formula turns a negative
+        // extraction into a negative fee, which would be built into a transaction as an amount.
+        expect(dev_fee_for(-5, FEE, "v3")).toBe(0n);
+        expect(dev_fee_for(-10_000, FEE, "v3")).toBe(0n);
+        expect(dev_fee_for(-10_000, FEE, "v2")).toBe(0n);
+    });
+
+    it("agrees with the figure the compiled v3 contract accepts", () => {
+        // devFeeOf is what tests/contracts/v3_invariants.test.ts pays in "should allow the same
+        // small withdrawal once the rounded-up fee is paid", against the compiled contract on a
+        // mock chain. Tying the two together is what makes this more than a restatement of the
+        // formula: if they ever diverge, one of the two suites is wrong and this says so.
+        for (const extracted of [1n, 19n, 20n, 21n, 99n, 100n, 1_000_000n]) {
+            expect(dev_fee_for(extracted, FEE, "v3")).toBe(devFeeOf(extracted, FEE));
+        }
+    });
+});

--- a/tests/frontend/fake_explorer.ts
+++ b/tests/frontend/fake_explorer.ts
@@ -1,0 +1,185 @@
+import { vi } from "vitest";
+import { get_dev_contract_hash, get_dev_fee } from "$lib/ergo/dev/dev_contract";
+
+/**
+ * A tiny in-memory stand-in for the Ergo explorer, serving only the three endpoints the lineage
+ * walk uses: `/api/v1/tokens/{id}`, `/api/v1/boxes/{boxId}` and `/api/v1/transactions/{txId}`.
+ *
+ * It records every path it is asked for, which is how the tests check that the cache actually
+ * saves work rather than merely returning the right answer twice.
+ */
+
+export const EXPLORER_URI = "https://explorer.test";
+
+export interface FakeBox {
+    boxId: string;
+    transactionId: string;
+    ergoTree: string;
+    value: number;
+    creationHeight: number;
+    assets: { tokenId: string; amount: number }[];
+    additionalRegisters: Record<string, any>;
+    spentTransactionId?: string | null;
+}
+
+export class FakeExplorer {
+    /** tokenId -> id of the box the token was minted in. */
+    tokens = new Map<string, string>();
+    boxes = new Map<string, FakeBox>();
+    txs = new Map<string, { id: string; outputs: FakeBox[] }>();
+    /** Every path requested, in order. */
+    calls: string[] = [];
+    /** Paths that should answer with a network-level failure rather than 404. */
+    unreachable = new Set<string>();
+    /**
+     * Boxes the unspent-by-token index does not list even though they are unspent - what a lagging
+     * or partial explorer index looks like from outside.
+     */
+    hiddenFromUnspent = new Set<string>();
+    /**
+     * Order of the unspent listing. Real explorers make no promise here, so tests that depend on
+     * picking the right box out of several should hold under both.
+     */
+    reverseUnspent = false;
+
+    private txCounter = 0;
+    private boxCounter = 0;
+
+    /** A box holding `tokenId` at index 0 - the shape the walk accepts as the project. */
+    box(tokenId: string | null, amount = 1, label?: string): FakeBox {
+        const boxId = label ?? `box${++this.boxCounter}`.padStart(64, "0");
+        const box: FakeBox = {
+            boxId,
+            transactionId: "",
+            ergoTree: "0008cd0000",
+            value: 1_000_000,
+            creationHeight: 800_000,
+            assets: tokenId === null ? [] : [{ tokenId, amount }],
+            additionalRegisters: {},
+            spentTransactionId: null,
+        };
+        this.boxes.set(boxId, box);
+        return box;
+    }
+
+    /** Register `box` as the box `tokenId` was minted in. */
+    mintedIn(tokenId: string, box: FakeBox) {
+        this.tokens.set(tokenId, box.boxId);
+    }
+
+    /** Spend `box` in a new transaction with the given outputs, in order. */
+    spend(box: FakeBox, outputs: FakeBox[]): string {
+        const txId = `tx${++this.txCounter}`;
+        const stored = this.boxes.get(box.boxId);
+        if (!stored) throw new Error(`spend() called on an unknown box ${box.boxId}`);
+        stored.spentTransactionId = txId;
+        for (const out of outputs) {
+            out.transactionId = txId;
+            this.boxes.set(out.boxId, out);
+        }
+        this.txs.set(txId, { id: txId, outputs });
+        return txId;
+    }
+
+    /** Install this explorer as `globalThis.fetch`. */
+    install() {
+        globalThis.fetch = vi.fn(async (url: any) => {
+            const full = String(url);
+            const path = full.startsWith(EXPLORER_URI) ? full.slice(EXPLORER_URI.length) : full;
+            this.calls.push(path);
+
+            if (this.unreachable.has(path)) throw new Error(`network error on ${path}`);
+
+            const body = this.route(path);
+            if (body === undefined) {
+                return { ok: false, status: 404, json: async () => ({}) } as any;
+            }
+            return { ok: true, status: 200, json: async () => body } as any;
+        }) as any;
+    }
+
+    /** How many times a path prefix was requested. */
+    countCalls(prefix: string): number {
+        return this.calls.filter((p) => p.startsWith(prefix)).length;
+    }
+
+    private route(path: string): any | undefined {
+        let match = path.match(/^\/api\/v1\/tokens\/(.+)$/);
+        if (match) {
+            const boxId = this.tokens.get(match[1]);
+            return boxId === undefined ? undefined : { id: match[1], boxId };
+        }
+
+        match = path.match(/^\/api\/v1\/boxes\/([^/]+)$/);
+        if (match) return this.boxes.get(match[1]);
+
+        match = path.match(/^\/api\/v1\/transactions\/(.+)$/);
+        if (match) return this.txs.get(match[1]);
+
+        match = path.match(/^\/api\/v1\/boxes\/unspent\/search\?(.*)$/);
+        if (match) {
+            const params = new URLSearchParams(match[1]);
+            const offset = Number(params.get("offset") ?? 0);
+            const limit = Number(params.get("limit") ?? 100);
+            // Everything that looks like a contract box: the scan matches on the ergo tree
+            // template, which these fixtures do not carry, so "has an R8" stands in for it.
+            const all = [...this.boxes.values()].filter(
+                (b) => !b.spentTransactionId && !this.hiddenFromUnspent.has(b.boxId) && b.additionalRegisters.R8
+            );
+            if (this.reverseUnspent) all.reverse();
+            return { items: all.slice(offset, offset + limit), total: all.length };
+        }
+
+        match = path.match(/^\/api\/v1\/boxes\/unspent\/byTokenId\/(.+?)(\?.*)?$/);
+        if (match) {
+            const items = [...this.boxes.values()].filter(
+                (b) =>
+                    !b.spentTransactionId &&
+                    !this.hiddenFromUnspent.has(b.boxId) &&
+                    b.assets.some((a) => a.tokenId === match![1])
+            );
+            if (this.reverseUnspent) items.reverse();
+            return { items, total: items.length };
+        }
+
+        return undefined;
+    }
+}
+
+export const PFT_TOKEN_ID = "d".repeat(64);
+
+/**
+ * Give a box the registers of a v2 project, so that `parseProjectBox` accepts it.
+ *
+ * Without this a fake box is rejected for having no registers, and a test meant to show that a
+ * box was *filtered out* would pass whether the filter ran or not.
+ */
+export function asV2Project(
+    box: FakeBox,
+    opts: { title?: string; pftTokenId?: string; pftAmount?: number; deadline?: number } = {}
+): FakeBox {
+    const pft = opts.pftTokenId ?? PFT_TOKEN_ID;
+    const owner = "0008cd03" + "11".repeat(32);
+    const content = JSON.stringify({
+        title: opts.title ?? "A project",
+        description: "",
+        link: null,
+        image: null,
+    });
+
+    box.assets = [box.assets[0], { tokenId: pft, amount: opts.pftAmount ?? 50_000 }];
+    box.additionalRegisters = {
+        R4: reg("(SBoolean, SLong)", `[false,${opts.deadline ?? 900_000}]`),
+        R5: reg("SLong", "1000"),
+        R6: reg("Coll[SLong]", "[0,0,0]"),
+        R7: reg("SLong", "1000000"),
+        // owner, dev contract hash, dev fee (hex), PFT id - and no base token, so ERG mode.
+        R8: reg("Coll[Coll[SByte]]", `[${owner},${get_dev_contract_hash()},${get_dev_fee().toString(16)},${pft}]`),
+        R9: reg("Coll[SByte]", Buffer.from(content, "utf-8").toString("hex")),
+    };
+    return box;
+}
+
+function reg(sigmaType: string, renderedValue: string) {
+    return { sigmaType, renderedValue, serializedValue: "00" };
+}

--- a/tests/frontend/fake_explorer.ts
+++ b/tests/frontend/fake_explorer.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { get_dev_contract_hash, get_dev_fee } from "$lib/ergo/dev/dev_contract";
+import { get_ergotree_hex, type contract_version } from "$lib/ergo/contract";
 
 /**
  * A tiny in-memory stand-in for the Ergo explorer, serving only the three endpoints the lineage
@@ -156,9 +157,20 @@ export const PFT_TOKEN_ID = "d".repeat(64);
  */
 export function asV2Project(
     box: FakeBox,
-    opts: { title?: string; pftTokenId?: string; pftAmount?: number; deadline?: number } = {}
+    opts: {
+        title?: string;
+        pftTokenId?: string;
+        pftAmount?: number;
+        deadline?: number;
+        version?: contract_version;
+    } = {}
 ): FakeBox {
+    const version = opts.version ?? "v2";
     const pft = opts.pftTokenId ?? PFT_TOKEN_ID;
+    // The script is what tells the versions apart - the registers do not, and neither do the
+    // tokens once a v2 campaign has sold down to its last APT. A fixture with a made-up ergo tree
+    // parses as nothing at all, which is the correct behaviour and worth having in the fixtures.
+    box.ergoTree = get_ergotree_hex({} as any, version);
     const owner = "0008cd03" + "11".repeat(32);
     const content = JSON.stringify({
         title: opts.title ?? "A project",

--- a/tests/frontend/legacy_version.test.ts
+++ b/tests/frontend/legacy_version.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { is_legacy_version, type Project } from "$lib/common/project";
+import { ErgoPlatform } from "$lib/ergo/platform";
+import type { contract_version } from "$lib/ergo/contract";
+
+/**
+ * The badge that marks a campaign as running on an older contract. The point of these tests is
+ * not the string on screen but the rule behind it: "older than what the platform deploys today",
+ * so that publishing a new contract marks the previous one on its own.
+ */
+
+function projectOn(version: string, deployed: string): Project {
+    return { version, platform: { last_version: deployed } } as unknown as Project;
+}
+
+describe("is_legacy_version", () => {
+    it("marks the versions older than the deployed one", () => {
+        expect(is_legacy_version(projectOn("v1_0", "v2"))).toBe(true);
+        expect(is_legacy_version(projectOn("v1_1", "v2"))).toBe(true);
+    });
+
+    it("leaves the deployed version unmarked", () => {
+        expect(is_legacy_version(projectOn("v2", "v2"))).toBe(false);
+    });
+
+    it("marks the previous version as soon as a new one is deployed", () => {
+        // Nobody has to come back and edit a list when v3 ships: v2 becomes legacy by itself, and
+        // v3 does not mark itself.
+        expect(is_legacy_version(projectOn("v2", "v3"))).toBe(true);
+        expect(is_legacy_version(projectOn("v3", "v3"))).toBe(false);
+    });
+
+    it("agrees with what the platform actually deploys right now", () => {
+        const deployed: contract_version = new ErgoPlatform().last_version;
+
+        expect(is_legacy_version(projectOn(deployed, deployed))).toBe(false);
+        expect(is_legacy_version(projectOn("v1_0", deployed))).toBe(true);
+    });
+});

--- a/tests/frontend/lineage.test.ts
+++ b/tests/frontend/lineage.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { explorer_uri } from "$lib/common/store";
+import {
+    resolveCanonicalBox,
+    isCanonicalBox,
+    clearLineageCache,
+} from "$lib/ergo/lineage";
+import { FakeExplorer, EXPLORER_URI, type FakeBox } from "./fake_explorer";
+
+/**
+ * The lineage walk is the answer to #176: a project has no verifiable identity in v1/v2, so the
+ * only thing that distinguishes the real box from an imitation is that it descends from the mint
+ * through OUTPUTS(0). These tests are about that distinction holding - and about the walk not
+ * inventing an answer when the chain cannot be read.
+ */
+
+const PROJECT_ID = "a".repeat(64);
+const OTHER_TOKEN = "b".repeat(64);
+
+let explorer: FakeExplorer;
+const realFetch = globalThis.fetch;
+
+/**
+ * A project with `actions` replications: mint -> genesis -> ... , the head left unspent.
+ * Returns the boxes in order, so a test can name the head or any ancestor.
+ */
+function campaign(actions: number): FakeBox[] {
+    const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+    explorer.mintedIn(PROJECT_ID, mintBox);
+
+    const genesis = explorer.box(PROJECT_ID, 100, "genesis");
+    explorer.spend(mintBox, [genesis]);
+
+    const chain = [genesis];
+    for (let i = 0; i < actions; i++) {
+        const next = explorer.box(PROJECT_ID, 100 - i - 1, `replica${i}`);
+        explorer.spend(chain[chain.length - 1], [next]);
+        chain.push(next);
+    }
+    return chain;
+}
+
+beforeEach(() => {
+    explorer = new FakeExplorer();
+    explorer.install();
+    explorer_uri.set(EXPLORER_URI);
+    clearLineageCache();
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+});
+
+describe("resolveCanonicalBox", () => {
+    it("reaches the head of the chain from the mint", async () => {
+        const chain = campaign(3);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box?.boxId).toBe(chain[chain.length - 1].boxId);
+        expect(result.ended).toBe(false);
+        expect(result.steps).toBe(4); // genesis + three replications
+    });
+
+    it("resolves a project that has never been spent since creation", async () => {
+        const chain = campaign(0);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box?.boxId).toBe(chain[0].boxId);
+        expect(result.ended).toBe(false);
+    });
+
+    it("reports the campaign as ended when the chain terminates", async () => {
+        const chain = campaign(2);
+        // A closing transaction pays the owner at OUTPUTS(0): no project token there.
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(true);
+    });
+
+    it("does not follow a box that carries a different token at index 0", async () => {
+        const chain = campaign(1);
+        // The project token is in the box, but not at index 0 - so by the contract's own `sameId`
+        // check this is not the project carried forward, whatever else it is.
+        const impostor = explorer.box(OTHER_TOKEN, 5, "impostor");
+        impostor.assets.push({ tokenId: PROJECT_ID, amount: 1 });
+        explorer.spend(chain[chain.length - 1], [impostor]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(true);
+    });
+
+    it("does not accept a creation output that is not at index 0", async () => {
+        // mint_idt.es requires the project at OUTPUTS(0), so a transaction that puts it elsewhere
+        // did not create a project this platform should recognise.
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        explorer.spend(mintBox, [explorer.box(OTHER_TOKEN, 1, "decoy"), explorer.box(PROJECT_ID, 100, "aside")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+});
+
+describe("what the walk refuses to conclude", () => {
+    it("treats an unknown token as unresolved, not as ended", async () => {
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("treats a never-spent mint box as unresolved", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("treats a creation transaction that does not produce the project as unresolved", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        explorer.spend(mintBox, [explorer.box(OTHER_TOKEN, 1, "notaproject")]);
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.box).toBeNull();
+        expect(result.ended).toBe(false);
+    });
+
+    it("reports the last box it knows, not 'ended', when the explorer has no answer for it", async () => {
+        const chain = campaign(1);
+        const head = chain[chain.length - 1];
+        explorer.boxes.delete(head.boxId); // the explorer 404s on a box it has just told us about
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        // Saying "ended" here would hide a live campaign on a transient explorer gap.
+        expect(result.ended).toBe(false);
+        expect(result.box?.boxId).toBe(head.boxId);
+    });
+
+    it("propagates a network failure rather than answering from nothing", async () => {
+        const chain = campaign(1);
+        explorer.unreachable.add(`/api/v1/boxes/${chain[chain.length - 1].boxId}`);
+
+        await expect(resolveCanonicalBox(PROJECT_ID)).rejects.toThrow();
+    });
+
+    it("stops instead of spinning when the chain loops back on itself", async () => {
+        const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+        explorer.mintedIn(PROJECT_ID, mintBox);
+        const a = explorer.box(PROJECT_ID, 100, "loopa");
+        const b = explorer.box(PROJECT_ID, 100, "loopb");
+        explorer.spend(mintBox, [a]);
+        explorer.spend(a, [b]);
+        explorer.spend(b, [a]); // a is now spent by two transactions: only a fixture can do this
+
+        const result = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(result.ended).toBe(false);
+        expect(result.steps).toBe(5000); // MAX_CHAIN_LENGTH
+    }, 30_000);
+});
+
+describe("isCanonicalBox", () => {
+    it("accepts the box the lineage reaches", async () => {
+        const chain = campaign(2);
+
+        expect(await isCanonicalBox(PROJECT_ID, chain[chain.length - 1].boxId)).toBe(true);
+    });
+
+    it("rejects an imitation that holds the project token but is not on the path", async () => {
+        campaign(2);
+        // Anyone holding one unit of the APT can build this: same token at index 0, unspent,
+        // and as far as `boxes/unspent/byTokenId` is concerned indistinguishable from the real one.
+        const imitation = explorer.box(PROJECT_ID, 1, "imitation");
+
+        expect(await isCanonicalBox(PROJECT_ID, imitation.boxId)).toBe(false);
+    });
+
+    it("rejects a clone slipped into the closing transaction at an index other than 0", async () => {
+        // This is #174: the transaction that ends the campaign also creates a copy, which the old
+        // by-token lookup then presented as the live project.
+        const chain = campaign(1);
+        const payout = explorer.box(null, 0, "payout");
+        const clone = explorer.box(PROJECT_ID, 1, "clone");
+        explorer.spend(chain[chain.length - 1], [payout, explorer.box(null, 0, "change"), clone]);
+
+        expect(await isCanonicalBox(PROJECT_ID, clone.boxId)).toBe(false);
+        expect((await resolveCanonicalBox(PROJECT_ID)).ended).toBe(true);
+    });
+
+    it("rejects an ancestor: the project is where the chain is now, not where it was", async () => {
+        const chain = campaign(3);
+
+        expect(await isCanonicalBox(PROJECT_ID, chain[0].boxId)).toBe(false);
+    });
+});
+
+describe("the cache", () => {
+    it("continues from where it stopped instead of walking from the mint again", async () => {
+        const chain = campaign(3);
+        await resolveCanonicalBox(PROJECT_ID);
+        const afterFirst = explorer.calls.length;
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.box?.boxId).toBe(chain[chain.length - 1].boxId);
+        expect(second.steps).toBe(0);
+        expect(explorer.calls.length).toBeLessThan(afterFirst);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(0);
+    });
+
+    it("picks up the actions taken since the last walk", async () => {
+        const chain = campaign(1);
+        await resolveCanonicalBox(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const later = explorer.box(PROJECT_ID, 50, "later");
+        explorer.spend(chain[chain.length - 1], [later]);
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.box?.boxId).toBe(later.boxId);
+        expect(second.steps).toBe(1);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(0);
+    });
+
+    it("answers an ended campaign without asking the explorer again", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        await resolveCanonicalBox(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.ended).toBe(true);
+        expect(explorer.calls.length).toBe(0);
+    });
+
+    it("walks again from the mint once cleared", async () => {
+        campaign(2);
+        await resolveCanonicalBox(PROJECT_ID);
+        clearLineageCache(PROJECT_ID);
+        explorer.calls.length = 0;
+
+        const second = await resolveCanonicalBox(PROJECT_ID);
+
+        expect(second.steps).toBe(3);
+        expect(explorer.countCalls("/api/v1/tokens/")).toBe(1);
+    });
+});

--- a/tests/frontend/project_lookup.test.ts
+++ b/tests/frontend/project_lookup.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { get } from "svelte/store";
+import { explorer_uri, projects, project_id_conflicts } from "$lib/common/store";
+import { clearLineageCache } from "$lib/ergo/lineage";
+import { fetchProjectById, fetchProjectsFromBlockchain } from "$lib/ergo/fetch";
+import { FakeExplorer, EXPLORER_URI, asV2Project, type FakeBox } from "./fake_explorer";
+
+/**
+ * #178 made the UI refuse to display a campaign when two unspent boxes claim its id, because
+ * nothing in the boxes says which is real. The lineage walk is what can say: the campaign is the
+ * box that descends from the mint through OUTPUTS(0). These tests are about the two halves fitting
+ * together - a collision the chain can settle is displayed, one it cannot is still refused - and
+ * about never falling back to "whichever box the explorer listed first".
+ *
+ * Every box a test expects to be rejected is built as a valid v2 project, so that rejecting it has
+ * to be the lineage's doing and not a parse failure.
+ */
+
+const PROJECT_ID = "c".repeat(64);
+
+let explorer: FakeExplorer;
+const realFetch = globalThis.fetch;
+
+function campaign(actions: number): FakeBox[] {
+    const mintBox = explorer.box(PROJECT_ID, 100, "mintbox");
+    explorer.mintedIn(PROJECT_ID, mintBox);
+    const genesis = asV2Project(explorer.box(PROJECT_ID, 100, "genesis"), { title: "The real one" });
+    explorer.spend(mintBox, [genesis]);
+
+    const chain = [genesis];
+    for (let i = 0; i < actions; i++) {
+        const next = asV2Project(explorer.box(PROJECT_ID, 100 - i - 1, `replica${i}`), {
+            title: "The real one",
+        });
+        explorer.spend(chain[chain.length - 1], [next]);
+        chain.push(next);
+    }
+    return chain;
+}
+
+/** The #176 box: same script, same token, registers of its author's choosing, never on the path. */
+function imitation(label: string): FakeBox {
+    return asV2Project(explorer.box(PROJECT_ID, 1, label), { title: "The fake one" });
+}
+
+beforeEach(() => {
+    explorer = new FakeExplorer();
+    explorer.install();
+    explorer_uri.set(EXPLORER_URI);
+    clearLineageCache();
+    projects.set({ data: new Map(), last_fetch: 0 });
+    project_id_conflicts.set(new Map());
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+});
+
+describe("the campaign page", () => {
+    // A real explorer promises nothing about the order of the unspent listing, and "whichever came
+    // first" is exactly the rule this replaces, so both orders are checked.
+    it.each([false, true])(
+        "shows the box the lineage reached, not the imitation beside it (reversed: %s)",
+        async (reversed) => {
+            explorer.reverseUnspent = reversed;
+            const chain = campaign(2);
+            imitation("imitation");
+
+            const project = await fetchProjectById(PROJECT_ID);
+
+            expect(project?.box.boxId).toBe(chain[chain.length - 1].boxId);
+            expect(project?.content.title).toBe("The real one");
+            // A collision the chain can settle is not a conflict any more.
+            expect(get(project_id_conflicts).has(PROJECT_ID)).toBe(false);
+        }
+    );
+
+    it("shows an ordinary campaign with nothing competing for its id", async () => {
+        const chain = campaign(1);
+
+        const project = await fetchProjectById(PROJECT_ID);
+
+        expect(project?.box.boxId).toBe(chain[chain.length - 1].boxId);
+    });
+
+    it("shows nothing for a campaign whose chain has ended", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        // A clone left unspent by the closing transaction - the #174 shape. It is the only box
+        // carrying the token now, so before this it was the campaign page.
+        imitation("clone");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+        expect(explorer.countCalls("/api/v1/boxes/unspent/")).toBe(0);
+    });
+
+    it("shows nothing when the box the lineage reached is not among the unspent ones", async () => {
+        const chain = campaign(1);
+        // The unspent index does not list the real box - a lagging index, say. The imitation is
+        // listed, and falling back to it is the one thing that must not happen.
+        explorer.hiddenFromUnspent.add(chain[chain.length - 1].boxId);
+        imitation("imitation");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+    });
+
+    it("still refuses a tie the lineage cannot settle", async () => {
+        // No mint registered: the walk cannot start, so nothing establishes which is which and the
+        // behaviour #178 introduced has to stand.
+        imitation("one");
+        imitation("two");
+
+        expect(await fetchProjectById(PROJECT_ID)).toBeNull();
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+
+    it("still shows a lone box when the lineage cannot be resolved", async () => {
+        // The explorer being unable to answer should not take every campaign off the site; with a
+        // single candidate there is nothing to be misled between, so this stays as it was.
+        asV2Project(explorer.box(PROJECT_ID, 100, "only"), { title: "Alone" });
+
+        expect((await fetchProjectById(PROJECT_ID))?.box.boxId).toBe("only");
+    });
+});
+
+describe("the campaign list", () => {
+    it.each([false, true])(
+        "lists the box the lineage reached when two claim one id (reversed: %s)",
+        async (reversed) => {
+            explorer.reverseUnspent = reversed;
+            const chain = campaign(1);
+            imitation("imitation");
+
+            await fetchProjectsFromBlockchain();
+
+            const listed = get(projects).data.get(PROJECT_ID);
+            expect(listed?.box.boxId).toBe(chain[chain.length - 1].boxId);
+            expect(listed?.content.title).toBe("The real one");
+            expect(get(project_id_conflicts).has(PROJECT_ID)).toBe(false);
+        }
+    );
+
+    it("lists a campaign untouched when nothing else claims its id", async () => {
+        const chain = campaign(1);
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.get(PROJECT_ID)?.box.boxId).toBe(chain[chain.length - 1].boxId);
+        // Nothing collided, so the walk should not have been paid for at all: one call per
+        // campaign per sweep is not a cost the listing can carry.
+        expect(explorer.countCalls("/api/v1/tokens/" + PROJECT_ID)).toBe(0);
+    });
+
+    it("hides the leftovers of a campaign that has ended", async () => {
+        const chain = campaign(1);
+        explorer.spend(chain[chain.length - 1], [explorer.box(null, 0, "payout")]);
+        imitation("clone");
+        imitation("another");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["clone", "another"]);
+    });
+
+    it("hides a collision when the real box is neither of the two", async () => {
+        // The campaign is live and its box is simply not in the unspent listing this sweep, while
+        // two imitations are. Neither is the campaign, and neither may be shown as one.
+        const chain = campaign(1);
+        explorer.hiddenFromUnspent.add(chain[chain.length - 1].boxId);
+        imitation("one");
+        imitation("two");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+
+    it("still hides a campaign whose collision the lineage cannot settle", async () => {
+        imitation("one");
+        imitation("two");
+
+        await fetchProjectsFromBlockchain();
+
+        expect(get(projects).data.has(PROJECT_ID)).toBe(false);
+        expect(get(project_id_conflicts).get(PROJECT_ID)).toEqual(["one", "two"]);
+    });
+});

--- a/tests/frontend/project_lookup.test.ts
+++ b/tests/frontend/project_lookup.test.ts
@@ -17,6 +17,7 @@ import { FakeExplorer, EXPLORER_URI, asV2Project, type FakeBox } from "./fake_ex
  */
 
 const PROJECT_ID = "c".repeat(64);
+const NFT_ID = "e".repeat(64);
 
 let explorer: FakeExplorer;
 const realFetch = globalThis.fetch;
@@ -124,6 +125,53 @@ describe("the campaign page", () => {
         asV2Project(explorer.box(PROJECT_ID, 100, "only"), { title: "Alone" });
 
         expect((await fetchProjectById(PROJECT_ID))?.box.boxId).toBe("only");
+    });
+
+    it("reads a sold-out v2 campaign as v2, not as v3", async () => {
+        // A v2 contract keeps one APT in the box so the token is always present, so a campaign
+        // that has sold out holds exactly 1 of it at index 0 - indistinguishable by tokens alone
+        // from v3's singleton NFT. Getting this wrong would put a v2 withdrawal on v3's fee rule,
+        // which the deployed contract rejects.
+        const box = asV2Project(explorer.box(PROJECT_ID, 1, "soldout"), { title: "Sold out" });
+        expect(box.assets[0].amount).toBe(1);
+
+        const project = await fetchProjectById(PROJECT_ID);
+
+        expect(project?.version).toBe("v2");
+        expect(project?.apt_token_id).toBe(PROJECT_ID);
+    });
+
+    it("reads a v3 campaign as v3", async () => {
+        const box = explorer.box(NFT_ID, 1, "v3box");
+        asV2Project(box, { title: "New style", version: "v3" });
+        // NFT at 0, APT at 1, PFT at 2 - the v3 layout.
+        box.assets = [
+            { tokenId: NFT_ID, amount: 1 },
+            { tokenId: PROJECT_ID, amount: 100_001 },
+            box.assets[1],
+        ];
+
+        const project = await fetchProjectById(NFT_ID);
+
+        expect(project?.version).toBe("v3");
+        expect(project?.project_id).toBe(NFT_ID);
+        expect(project?.apt_token_id).toBe(PROJECT_ID);
+        expect(project?.current_idt_amount).toBe(100_001);
+    });
+
+    it("refuses a v3-scripted box whose first token is not a singleton", async () => {
+        // The v3 script is public and anyone can lock a box with it. What they cannot do is put a
+        // singleton at tokens(0) whose id comes from a box that no longer exists - so a lookalike
+        // has to carry something else there, and that is what this catches.
+        const box = explorer.box(NFT_ID, 5, "lookalike");
+        asV2Project(box, { title: "Not a campaign", version: "v3" });
+        box.assets = [
+            { tokenId: NFT_ID, amount: 5 },
+            { tokenId: PROJECT_ID, amount: 100_001 },
+            box.assets[1],
+        ];
+
+        expect(await fetchProjectById(NFT_ID)).toBeNull();
     });
 });
 

--- a/tests/frontend/replica.test.ts
+++ b/tests/frontend/replica.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { OutputBuilder, SAFE_MIN_BOX_VALUE } from "@fleet-sdk/core";
+import { addIdentityTokens, project_token_count } from "$lib/ergo/replica";
+import type { Project } from "$lib/common/project";
+
+/**
+ * The contract reads identity and balances by token index, so the order these are added in is not
+ * cosmetic: a v3 box without its NFT at index 0, or with the APT in the wrong place, is a box the
+ * contract rejects. v3 also separated the two ids that v2 conflated - the NFT identifies, the APT
+ * circulates - and using one where the other belongs is the mistake this guards against.
+ */
+
+const NFT = "n".repeat(64);
+const APT = "a".repeat(64);
+
+function project(version: string, ids: { project_id: string; apt_token_id: string }): Project {
+    return { version, ...ids } as unknown as Project;
+}
+
+function tokensOf(output: OutputBuilder) {
+    return output.assets.toArray().map((t: any) => ({
+        tokenId: t.tokenId,
+        amount: BigInt(t.amount),
+    }));
+}
+
+describe("addIdentityTokens", () => {
+    it("puts the singleton NFT first and the APT second on v3", () => {
+        const output = new OutputBuilder(SAFE_MIN_BOX_VALUE, "0008cd" + "02".repeat(33));
+
+        addIdentityTokens(output, project("v3", { project_id: NFT, apt_token_id: APT }), 500n);
+
+        expect(tokensOf(output)).toEqual([
+            { tokenId: NFT, amount: 1n },
+            { tokenId: APT, amount: 500n },
+        ]);
+    });
+
+    it("adds the APT alone on v2, where it is also the identity", () => {
+        const output = new OutputBuilder(SAFE_MIN_BOX_VALUE, "0008cd" + "02".repeat(33));
+
+        addIdentityTokens(output, project("v2", { project_id: APT, apt_token_id: APT }), 500n);
+
+        expect(tokensOf(output)).toEqual([{ tokenId: APT, amount: 500n }]);
+    });
+
+    it("moves the APT, not the NFT, when the amount changes", () => {
+        // A purchase lowers the APT in the box. The NFT is not a balance and never moves.
+        const output = new OutputBuilder(SAFE_MIN_BOX_VALUE, "0008cd" + "02".repeat(33));
+
+        addIdentityTokens(output, project("v3", { project_id: NFT, apt_token_id: APT }), 1n);
+
+        expect(tokensOf(output)).toEqual([
+            { tokenId: NFT, amount: 1n },
+            { tokenId: APT, amount: 1n },
+        ]);
+    });
+
+    it("counts the minted NFT when sizing a v3 box", () => {
+        // The count feeds the minimum-value estimate. Leaving the NFT out of it builds a box that
+        // may fall under the value the network requires for its size.
+        expect(project_token_count("v3", 2)).toBe(3);
+        expect(project_token_count("v2", 2)).toBe(2);
+        expect(project_token_count("v1_0", 2)).toBe(2);
+    });
+
+    it("does not reuse the project id for the APT on v3", () => {
+        // The two are different tokens from v3 on; spending the NFT id as if it were the APT would
+        // build a transaction the contract rejects, and it is the easy mistake to make.
+        const output = new OutputBuilder(SAFE_MIN_BOX_VALUE, "0008cd" + "02".repeat(33));
+
+        addIdentityTokens(output, project("v3", { project_id: NFT, apt_token_id: APT }), 500n);
+        const tokens = tokensOf(output);
+
+        expect(tokens.filter((t) => t.tokenId === NFT)).toHaveLength(1);
+        expect(tokens.find((t) => t.tokenId === NFT)!.amount).toBe(1n);
+        expect(tokens.find((t) => t.tokenId === APT)!.amount).toBe(500n);
+    });
+});

--- a/tests/stubs/wallet-svelte-component.ts
+++ b/tests/stubs/wallet-svelte-component.ts
@@ -1,0 +1,35 @@
+// Stub for wallet-svelte-component.
+//
+// The published package ships Svelte components and extensionless ESM imports that Node cannot
+// resolve, so vitest dies during collection with ERR_MODULE_NOT_FOUND before running a single
+// test - including the tests already in the repo. It is pulled in transitively by $lib, so
+// aliasing it to this module in vitest.config.ts is what lets the suite run at all.
+//
+// The surface here is deliberately the smallest thing that keeps module initialisation working:
+// stores that can be subscribed to and written, and wallet calls that refuse loudly. Nothing
+// under tests/ signs or submits anything, so a test that reaches one of these has gone wrong and
+// should say so rather than quietly do nothing.
+import { writable } from "svelte/store";
+
+export const explorerUri = writable<string>("https://api.ergoplatform.com");
+export const walletConnected = writable<boolean>(false);
+export const walletAddress = writable<string>("");
+
+const notInTests = (name: string) => async () => {
+    throw new Error(`${name}() is not available in tests: the wallet is stubbed out`);
+};
+
+export const walletManager = {
+    connectWallet: notInTests("walletManager.connectWallet"),
+    disconnect: notInTests("walletManager.disconnect"),
+};
+
+export const getCurrentHeight = notInTests("getCurrentHeight");
+export const getChangeAddress = notInTests("getChangeAddress");
+export const signTransaction = notInTests("signTransaction");
+export const submitTransaction = notInTests("submitTransaction");
+export const getUtxos = notInTests("getUtxos");
+
+export const WalletAddressChangeHandler = {};
+
+export default {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   resolve: {
     alias: {
       $lib: path.resolve(__dirname, './src/lib'),
+      // wallet-svelte-component ships .svelte files and extensionless ESM imports that Node
+      // cannot resolve, so vitest dies during collection - before running a single test,
+      // including the ones already in the repo. It is pulled in transitively by $lib and no
+      // test touches it, so it is stubbed out here.
+      'wallet-svelte-component': path.resolve(__dirname, './tests/stubs/wallet-svelte-component.ts'),
     },
   },
 });


### PR DESCRIPTION
### Addressed Issues:

The frontend half of #176 and #177. The contract half is #179; this makes the platform able to create, read and spend campaigns that use it.

Stacked on #181, which is stacked on main, and it carries #179's four contract files unchanged so the branch runs on its own. If #179 and #181 land first, this shrinks to its own commits; if they do not, everything here is still reviewable and testable as it stands.

### Screenshots/Recordings:

Nothing visible changes for an existing campaign. The one visible effect is that the legacy badge from #181 starts marking v2 - by design, since v3 becomes the deployed version - and the screenshot in #181 shows it.

### Additional Notes:

**Identity (#176).** `Project` gains `apt_token_id`. Before v3 one token did both jobs, identifying the campaign and circulating to contributors, which is the whole of #176. They are separate now, and `project_id` keeps its name and meaning, so every URL, store key and forum topic stays where it was.

Creation mints the NFT in Tx B. Its id is the id of `INPUTS(0)`, and `INPUTS(0)` of Tx B is the mint box - just spent, never reproducible. The identity costs no extra transaction and no extra box. A v3 box therefore does not need the lineage walk from #181; the walk stays for the v1 and v2 campaigns already on chain, which will not be migrated.

**The dev fee (#177).** The fee follows the contract of the box being spent: rounded up on v3, truncated on v1 and v2. The old behaviour is not a bug to fix for the old versions - those contracts are on chain, they compute the truncated figure themselves and compare it exactly, so offering more builds a transaction they reject. Done in `BigInt`, because on a token campaign the product passes 2^53 and a fee off by one is not a rounding difference: the transaction fails.

**Two things found on the way.** `get_ergotree_hex`, `get_contract_hash` and `mint_contract_address` each took a `version` argument and ignored it, always returning v2 - harmless while v2 was the only rebuildable version, a live trap the moment a second one exists. And `withdraw.ts` converted amounts to smallest units without rounding: `1.07 ERG` gives `1070000000.0000001` nanoERG, `2.01` gives `2009999999.9999998`, and `BigInt()` refuses anything fractional, so roughly one in thirty two-decimal amounts failed with an opaque error. The other five actions already guarded that multiplication.

**Telling v2 from v3.** A v2 contract keeps one APT in the box so the token is always present, so a sold-out campaign holds exactly 1 at `tokens(0)` - by tokens alone, indistinguishable from v3's singleton NFT. Reading it as v3 would put its withdrawal on the wrong fee rule. So a box is checked against the compiled script of the version it claims, which is the same check the contract makes when it replicates; the compiled tree is cached, since this now happens for every box read.

**Tests.** `tests/contracts/v3_creation.test.ts` runs the production builder - the same `buildProjectOutput` that `submit.ts` calls - through Tx A and Tx B on a mock chain against the compiled `mint_idt_v3` and `contract_v3`. Which token lands at index 0, and which input is first, are decided when the transaction is built and cannot be read off the builder; the contract is the only authority. Three negative controls: no NFT, an identity token minted with amount 2, and the mint box not spent first. `dev_fee.test.ts` ties the frontend's figure to the one the compiled contract accepts, by comparing against the helper the mock-chain suite pays with, so the two cannot drift apart silently.

58 frontend and creation tests. I mutated the code under test 13 ways across two passes - drop the script check, accept any amount at `tokens(0)`, read the APT from index 0 on v3, never mint the NFT, size the box without it, truncate on v3, round up on v2, and so on. All 13 are caught; four earlier mutants survived and each pointed at a real gap.

`npm test`: **8 failed | 173 passed**. The 8 are the ones already on main - the 7 listed in #180 plus `replication_guard.test.ts` from #174, red on purpose. None of them touch this.

**Not in this PR.** Duplicating the whole v2 contract suite for v3. #179 covers the invariants that changed and this covers creation; the rest of the behaviour is unchanged from v2 and the existing suite still exercises it there. Worth doing, but as its own piece of work.